### PR TITLE
fix: add orchestrator-staging service to docker-compose.prod.yml

### DIFF
--- a/deploy/vps/docker-compose.prod.yml
+++ b/deploy/vps/docker-compose.prod.yml
@@ -70,6 +70,28 @@ services:
       meshwiki:
         condition: service_healthy
 
+  orchestrator-staging:
+    image: ghcr.io/jyrkihuhta/meshwiki-orchestrator:${ORCHESTRATOR_VERSION:-latest}
+    restart: unless-stopped
+    env_file: /opt/meshwiki/orchestrator-staging.env
+    volumes:
+      - orchestrator_staging_data:/data
+    expose:
+      - "8002"
+    healthcheck:
+      test:
+        - CMD
+        - python3
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8002/health')"
+      interval: 30s
+      timeout: 10s
+      start_period: 15s
+      retries: 3
+    depends_on:
+      meshwiki-staging:
+        condition: service_healthy
+
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
@@ -88,3 +110,4 @@ volumes:
   caddy_data:
   caddy_config:
   orchestrator_data:
+  orchestrator_staging_data:


### PR DESCRIPTION
## Summary

- Adds `orchestrator-staging` service definition to `deploy/vps/docker-compose.prod.yml`
- Adds `orchestrator_staging_data` named volume for the staging SQLite checkpoints
- The staging orchestrator was running as a Docker Compose **orphan** — CI copies `docker-compose.prod.yml` to the VPS on every staging deploy, but the service was never in the file, so `docker compose up -d orchestrator-staging` silently failed (with `|| true`)

## Test plan

- [ ] Merge and let CI run the staging deploy job
- [ ] Verify `docker compose ps` on VPS shows `orchestrator-staging` as a managed service (not orphan)
- [ ] Verify the new SQLite volume `orchestrator_staging_data` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)