### PR TITLE
[Factory] Add <<RecentChanges>> macro

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -289,27 +289,12 @@ def _timeago(dt: datetime | None) -> str:
         return dt.strftime("%Y-%m-%d")
 
 
-def _render_recent_changes(n: int = 10) -> str:
+def _render_recent_changes(pages: list, n: int = 10) -> str:
     """Render the <<RecentChanges(n)>> macro as an HTML list of recent pages."""
-    try:
-        from meshwiki.core.dependencies import get_storage
-
-        storage = get_storage()
-    except RuntimeError:
+    if not pages:
         return (
             '<div class="recent-changes-wrapper">'
-            '<p class="recent-changes-unavailable">'
-            "<em>RecentChanges: storage not available</em></p></div>"
-        )
-
-    try:
-        import asyncio
-
-        pages = asyncio.run(storage.list_pages_with_metadata())
-    except Exception as e:
-        return (
-            f'<div class="recent-changes-wrapper">'
-            f'<p class="recent-changes-error"><em>RecentChanges error: {e}</em></p></div>'
+            '<p class="recent-changes-empty"><em>No pages found</em></p></div>'
         )
 
     filtered = [p for p in pages if not p.name.startswith("Factory/")]
@@ -343,6 +328,10 @@ def _render_recent_changes(n: int = 10) -> str:
 class RecentChangesPreprocessor(Preprocessor):
     """Preprocessor that replaces <<RecentChanges(n)>> macros with an HTML list."""
 
+    def __init__(self, md: Markdown, recent_pages: list | None):
+        super().__init__(md)
+        self.recent_pages = recent_pages or []
+
     def run(self, lines: list[str]) -> list[str]:
         text = "\n".join(lines)
         if "<<RecentChanges" not in text:
@@ -361,7 +350,7 @@ class RecentChangesPreprocessor(Preprocessor):
         def replace_match(m: re.Match) -> str:
             n_str = m.group(1)
             n = int(n_str) if n_str else 10
-            html = _render_recent_changes(n)
+            html = _render_recent_changes(self.recent_pages, n)
             return self.md.htmlStash.store(html)
 
         text = RECENTCHANGES_PATTERN.sub(replace_match, text)
@@ -375,9 +364,13 @@ class RecentChangesPreprocessor(Preprocessor):
 class RecentChangesExtension(Extension):
     """Markdown extension for <<RecentChanges(n)>> macros."""
 
+    def __init__(self, recent_pages: list | None = None, **kwargs):
+        self.recent_pages = recent_pages or []
+        super().__init__(**kwargs)
+
     def extendMarkdown(self, md: Markdown) -> None:
         md.preprocessors.register(
-            RecentChangesPreprocessor(md),
+            RecentChangesPreprocessor(md, self.recent_pages),
             "recentchanges",
             29,
         )
@@ -900,6 +893,7 @@ def create_parser(
     page_exists: Callable[[str], bool] | None = None,
     page_name: str | None = None,
     page_metadata: dict | None = None,
+    recent_pages: list | None = None,
 ) -> Markdown:
     """Create a Markdown parser with wiki link support.
 
@@ -908,6 +902,7 @@ def create_parser(
                     Used to style missing page links differently.
         page_name: Name of the page being rendered (for TaskStatus macro).
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
+        recent_pages: List of Page objects for RecentChanges macro.
 
     Returns:
         Configured Markdown parser instance.
@@ -931,7 +926,7 @@ def create_parser(
             EpicStatusExtension(
                 page_name=page_name, page_metadata=page_metadata
             ),  # <<EpicStatus>>
-            RecentChangesExtension(),  # <<RecentChanges(n)>>
+            RecentChangesExtension(recent_pages=recent_pages),  # <<RecentChanges(n)>>
             PageCountExtension(),  # <<PageCount>>
         ]
     )
@@ -942,6 +937,7 @@ def parse_wiki_content(
     page_exists: Callable[[str], bool] | None = None,
     page_name: str | None = None,
     page_metadata: dict | None = None,
+    recent_pages: list | None = None,
 ) -> str:
     """Parse wiki content (Markdown + wiki links) to HTML.
 
@@ -950,12 +946,16 @@ def parse_wiki_content(
         page_exists: Callback to check if a page exists.
         page_name: Name of the page being rendered (for TaskStatus macro).
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
+        recent_pages: List of Page objects for RecentChanges macro.
 
     Returns:
         HTML string.
     """
     parser = create_parser(
-        page_exists, page_name=page_name, page_metadata=page_metadata
+        page_exists,
+        page_name=page_name,
+        page_metadata=page_metadata,
+        recent_pages=recent_pages,
     )
     return parser.convert(content)
 
@@ -965,6 +965,7 @@ def parse_wiki_content_with_toc(
     page_exists: Callable[[str], bool] | None = None,
     page_name: str | None = None,
     page_metadata: dict | None = None,
+    recent_pages: list | None = None,
 ) -> tuple[str, str]:
     """Parse wiki content and return HTML with table of contents.
 
@@ -973,12 +974,16 @@ def parse_wiki_content_with_toc(
         page_exists: Callback to check if a page exists.
         page_name: Name of the page being rendered (for TaskStatus macro).
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
+        recent_pages: List of Page objects for RecentChanges macro.
 
     Returns:
         Tuple of (html_content, toc_html).
     """
     parser = create_parser(
-        page_exists, page_name=page_name, page_metadata=page_metadata
+        page_exists,
+        page_name=page_name,
+        page_metadata=page_metadata,
+        recent_pages=recent_pages,
     )
     html = parser.convert(content)
     toc_html = getattr(parser, "toc", "")

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -414,12 +414,21 @@ async def view_page(request: Request, name: str):
                 child_tasks.append({"name": p.name, "title": p.title, "status": status})
         frontmatter["_child_tasks"] = child_tasks
 
+    # Fetch recent pages for <<RecentChanges>> macro.
+    all_pages = await storage.list_pages_with_metadata()
+    recent_pages = sorted(
+        [p for p in all_pages if p.metadata.modified],
+        key=lambda p: p.metadata.modified,
+        reverse=True,
+    )
+
     # Parse content with wiki links, TOC, and page context for macros.
     html_content, toc_html = parse_wiki_content_with_toc(
         page.content,
         page_exists=page_exists_sync,
         page_name=name,
         page_metadata=frontmatter,
+        recent_pages=recent_pages,
     )
 
     return templates.TemplateResponse(
@@ -497,7 +506,12 @@ async def save_page(request: Request, name: str, content: str = Form("")):
 @app.post("/api/preview", response_class=HTMLResponse)
 async def api_preview(content: str = Form("")):
     """Render markdown preview for the editor."""
-    html = parse_wiki_content(content, page_exists=page_exists_sync)
+    recent_pages = await storage.list_pages_with_metadata()
+    html = parse_wiki_content(
+        content,
+        page_exists=page_exists_sync,
+        recent_pages=recent_pages,
+    )
     return HTMLResponse(html)
 
 

--- a/src/tests/test_recent_changes_macro.py
+++ b/src/tests/test_recent_changes_macro.py
@@ -1,25 +1,11 @@
 """Unit tests for the <<RecentChanges>> macro."""
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
+
+import pytest
 
 from meshwiki.core.models import Page, PageMetadata
 from meshwiki.core.parser import parse_wiki_content
-
-
-def render(content: str) -> str:
-    """Helper: render wiki content with RecentChanges context."""
-    return parse_wiki_content(content)
-
-
-class MockStorage:
-    """Mock FileStorage for testing RecentChanges macro."""
-
-    def __init__(self, pages: list[Page]):
-        self._pages = pages
-
-    async def list_pages_with_metadata(self) -> list[Page]:
-        return self._pages
 
 
 def make_page(name: str, minutes_ago: int = 0) -> Page:
@@ -43,45 +29,40 @@ class TestRecentChangesBasic:
             make_page("Page B", minutes_ago=10),
             make_page("Page C", minutes_ago=15),
         ]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            assert "recent-changes-wrapper" in html
-            assert "recent-changes-list" in html
-            assert "Page A" in html
-            assert "Page B" in html
-            assert "Page C" in html
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        assert "recent-changes-wrapper" in html
+        assert "recent-changes-list" in html
+        assert "Page A" in html
+        assert "Page B" in html
+        assert "Page C" in html
 
     def test_default_limit_is_10(self):
         """<<RecentChanges>> defaults to showing 10 pages."""
         pages = [make_page(f"Page {i}", minutes_ago=i) for i in range(15)]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            count = html.count("recent-changes-item")
-            assert count == 10
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        count = html.count("recent-changes-item")
+        assert count == 10
 
     def test_custom_n_limit(self):
         """<<RecentChanges(5)>> shows exactly 5 pages."""
         pages = [make_page(f"Page {i}", minutes_ago=i) for i in range(10)]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges(5)>>")
-            count = html.count("recent-changes-item")
-            assert count == 5
+        html = parse_wiki_content("<<RecentChanges(5)>>", recent_pages=pages)
+        count = html.count("recent-changes-item")
+        assert count == 5
 
     def test_wiki_link_for_each_page(self):
         """Each entry is a wiki link to the page."""
         pages = [make_page("TestPage", minutes_ago=5)]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            assert 'href="/page/TestPage"' in html
-            assert 'class="wiki-link">TestPage</a>' in html
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        assert 'href="/page/TestPage"' in html
+        assert 'class="wiki-link">TestPage</a>' in html
 
     def test_relative_time_displayed(self):
         """Each entry shows relative modification time."""
         pages = [make_page("RecentPage", minutes_ago=30)]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            assert "recent-changes-time" in html
-            assert "30m ago" in html
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        assert "recent-changes-time" in html
+        assert "30m ago" in html
 
 
 class TestRecentChangesFiltering:
@@ -94,14 +75,13 @@ class TestRecentChangesFiltering:
             make_page("Factory/Task_001", minutes_ago=1),
             make_page("AnotherPage", minutes_ago=10),
         ]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            assert "RegularPage" in html
-            assert "AnotherPage" in html
-            assert "Factory/Task_001" not in html
-            assert "recent-changes-item" in html
-            count = html.count("recent-changes-item")
-            assert count == 2
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        assert "RegularPage" in html
+        assert "AnotherPage" in html
+        assert "Factory/Task_001" not in html
+        assert "recent-changes-item" in html
+        count = html.count("recent-changes-item")
+        assert count == 2
 
 
 class TestRecentChangesEdgeCases:
@@ -109,44 +89,43 @@ class TestRecentChangesEdgeCases:
 
     def test_empty_wiki(self):
         """<<RecentChanges>> on empty wiki shows empty message."""
-        with patch("meshwiki.core.dependencies._storage", MockStorage([])):
-            html = render("<<RecentChanges>>")
-            assert "recent-changes-empty" in html
-            assert "No pages found" in html
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=[])
+        assert "recent-changes-empty" in html
+        assert "No pages found" in html
 
-    def test_storage_not_initialized(self):
-        """<<RecentChanges>> handles uninitialized storage gracefully."""
-        with patch("meshwiki.core.dependencies._storage", None):
-            html = render("<<RecentChanges>>")
-            assert "recent-changes-unavailable" in html
-            assert "storage not available" in html
+    def test_no_recent_pages_arg(self):
+        """<<RecentChanges>> with no recent_pages arg shows empty message."""
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=None)
+        assert "recent-changes-empty" in html
 
     def test_not_replaced_in_fenced_code_block(self):
         """<<RecentChanges>> inside code blocks is escaped, not rendered."""
         content = "```\n<<RecentChanges>>\n```"
-        html = render(content)
+        html = parse_wiki_content(
+            content, recent_pages=[make_page("Test", minutes_ago=1)]
+        )
         assert "recent-changes-wrapper" not in html
         assert "&lt;&lt;RecentChanges&gt;&gt;" in html
 
     def test_not_replaced_in_tilde_code_block(self):
         """<<RecentChanges>> inside ~~~ code blocks is escaped, not rendered."""
         content = "~~~\n<<RecentChanges>>\n~~~"
-        html = render(content)
+        html = parse_wiki_content(
+            content, recent_pages=[make_page("Test", minutes_ago=1)]
+        )
         assert "recent-changes-wrapper" not in html
 
     def test_custom_n_with_no_pages(self):
         """<<RecentChanges(5)>> with no pages shows empty message."""
-        with patch("meshwiki.core.dependencies._storage", MockStorage([])):
-            html = render("<<RecentChanges(5)>>")
-            assert "recent-changes-empty" in html
+        html = parse_wiki_content("<<RecentChanges(5)>>", recent_pages=[])
+        assert "recent-changes-empty" in html
 
     def test_page_name_with_spaces(self):
         """Page names with spaces are properly linked."""
         pages = [make_page("My Page Name", minutes_ago=5)]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            assert 'href="/page/My_Page_Name"' in html
-            assert 'class="wiki-link">My Page Name</a>' in html
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        assert 'href="/page/My_Page_Name"' in html
+        assert 'class="wiki-link">My Page Name</a>' in html
 
 
 class TestRecentChangesSorting:
@@ -159,12 +138,11 @@ class TestRecentChangesSorting:
             make_page("NewPage", minutes_ago=1),
             make_page("MidPage", minutes_ago=50),
         ]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            new_idx = html.find("NewPage")
-            mid_idx = html.find("MidPage")
-            old_idx = html.find("OldPage")
-            assert new_idx < mid_idx < old_idx
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        new_idx = html.find("NewPage")
+        mid_idx = html.find("MidPage")
+        old_idx = html.find("OldPage")
+        assert new_idx < mid_idx < old_idx
 
     def test_pages_without_modified_time_last(self):
         """Pages with no modified time appear at the end."""
@@ -181,8 +159,30 @@ class TestRecentChangesSorting:
             exists=True,
         )
         pages = [page_without_time, page_with_time]
-        with patch("meshwiki.core.dependencies._storage", MockStorage(pages)):
-            html = render("<<RecentChanges>>")
-            timed_idx = html.find("TimedPage")
-            notime_idx = html.find("NoTimePage")
-            assert timed_idx < notime_idx
+        html = parse_wiki_content("<<RecentChanges>>", recent_pages=pages)
+        timed_idx = html.find("TimedPage")
+        notime_idx = html.find("NoTimePage")
+        assert timed_idx < notime_idx
+
+
+class TestRecentChangesMacroViaApi:
+    """Render <<RecentChanges>> through the real FastAPI route."""
+
+    @pytest.mark.asyncio
+    async def test_recent_changes_renders_via_route(self, tmp_path):
+        import meshwiki.main
+
+        meshwiki.main.storage.base_path = tmp_path
+        await meshwiki.main.storage.save_page(
+            "RCMacroTest", "Recent: <<RecentChanges>>"
+        )
+
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=meshwiki.main.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/page/RCMacroTest")
+
+        assert resp.status_code == 200
+        assert "recent-changes-wrapper" in resp.text
+        assert "recent-changes-list" in resp.text


### PR DESCRIPTION
## Summary
- Refactor `RecentChangesExtension` to use constructor injection (pass `recent_pages` list) instead of `asyncio.run()` inside the preprocessor, which would fail when called from within an async event loop
- Update `view_page` and `api_preview` routes to fetch recent pages and pass them to the parser
- Update tests to use new API (pass pages directly instead of mocking storage)
- Add `TestRecentChangesMacroViaApi` for route-level testing

## Changes
- `src/meshwiki/core/parser.py`: Refactored `RecentChangesExtension`/`RecentChangesPreprocessor` to accept `recent_pages` via constructor; updated `create_parser()`, `parse_wiki_content()`, and `parse_wiki_content_with_toc()` to accept and pass `recent_pages`
- `src/meshwiki/main.py`: `view_page` and `api_preview` now fetch recent pages and pass them to the parser
- `src/tests/test_recent_changes_macro.py`: Rewrote tests to use new API; added API-level test

## Testing
- `pytest src/tests/ -x -q` passes (389 tests)
- `black src/ --check && isort --profile black src/ --check && ruff check src/` pass