### PR TITLE
fix: remove checkpoint_tuple.next check (crash-loop on startup)

### DIFF
--- a/orchestrator/factory/webhook_server.py
+++ b/orchestrator/factory/webhook_server.py
@@ -61,11 +61,6 @@ async def _resume_interrupted_tasks(graph, saver, settings) -> None:
             logger.info("factory: no checkpoint for %s — skipping resume", page_name)
             continue
 
-        # Skip if the graph already reached END (no pending nodes).
-        if not checkpoint_tuple.next:
-            logger.info("factory: checkpoint for %s is at END — skipping resume", page_name)
-            continue
-
         logger.info(
             "factory: resuming interrupted task %s from checkpoint (next nodes: %s)",
             page_name,

--- a/orchestrator/factory/webhook_server.py
+++ b/orchestrator/factory/webhook_server.py
@@ -21,12 +21,13 @@ logger = logging.getLogger(__name__)
 
 
 async def _resume_interrupted_tasks(graph, saver, settings) -> None:
-    """On startup, resume any tasks that were in_progress when the orchestrator died.
+    """On startup, resume any tasks that were active when the orchestrator died.
 
     Strategy:
-    1. Ask MeshWiki for all tasks with status=in_progress and assignee=factory.
+    1. Ask MeshWiki for all tasks with status=in_progress or status=review
+       that are assigned to factory (both statuses represent active graph runs).
     2. For each, check if the SQLite checkpointer has a saved state.
-    3. If yes, call ainvoke({}) with the same thread_id — LangGraph resumes
+    3. If yes, call ainvoke(None) with the same thread_id — LangGraph resumes
        from the last node boundary rather than restarting from scratch.
     """
     client = MeshWikiClient(settings.meshwiki_url, settings.meshwiki_api_key)
@@ -37,7 +38,11 @@ async def _resume_interrupted_tasks(graph, saver, settings) -> None:
         except Exception as exc:
             logger.warning("factory: could not fetch %s tasks on startup: %s", status, exc)
             continue
-        all_factory_tasks.extend(t for t in tasks if t.get("assignee") == "factory")
+        all_factory_tasks.extend(
+            t for t in tasks
+            if t.get("metadata", {}).get("assignee") == "factory"
+            or t.get("assignee") == "factory"  # flat format (defensive)
+        )
 
     if not all_factory_tasks:
         return


### PR DESCRIPTION
## Summary

**Critical fix — orchestrator is crash-looping on staging.**

- `CheckpointTuple._fields` = `('config', 'checkpoint', 'metadata', 'parent_config', 'pending_writes')` — no `next` attribute
- The startup resume code checked `checkpoint_tuple.next` → `AttributeError` → startup failed → Docker restarted → infinite crash loop
- The original check was intended to skip tasks that had already completed; it was written with an incorrect assumption about the LangGraph API

## Fix

Remove the check entirely. `ainvoke(None)` on a completed graph returns immediately with the final state — no harm, no re-execution of side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)