### PR TITLE
fix: remove remaining checkpoint_tuple.next in log message (crash-loop)

### DIFF
--- a/orchestrator/factory/webhook_server.py
+++ b/orchestrator/factory/webhook_server.py
@@ -61,11 +61,7 @@ async def _resume_interrupted_tasks(graph, saver, settings) -> None:
             logger.info("factory: no checkpoint for %s — skipping resume", page_name)
             continue
 
-        logger.info(
-            "factory: resuming interrupted task %s from checkpoint (next nodes: %s)",
-            page_name,
-            checkpoint_tuple.next,
-        )
+        logger.info("factory: resuming interrupted task %s from checkpoint", page_name)
 
         def _log_exc(t: asyncio.Task, name: str = page_name) -> None:
             if not t.cancelled() and (exc := t.exception()):


### PR DESCRIPTION
## Summary

Followup to #91 — after removing the `if not checkpoint_tuple.next:` guard, a log message that also used `checkpoint_tuple.next` remained:

```python
logger.info(
    "factory: resuming interrupted task %s from checkpoint (next nodes: %s)",
    page_name,
    checkpoint_tuple.next,  # ← AttributeError
)
```

This caused the same `AttributeError: 'CheckpointTuple' object has no attribute 'next'` crash loop on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)