### PR TITLE
fix: include PM review feedback in rework grinder task prompt

### DIFF
--- a/orchestrator/factory/agents/grinder_agent.py
+++ b/orchestrator/factory/agents/grinder_agent.py
@@ -496,19 +496,41 @@ async def grind_subtask_e2b(
         logger.error("e2b grinder: failed to fetch wiki page: %s", exc)
 
     base_branch = settings.pr_base_branch
+    review_feedback = subtask.get("review_feedback") or ""
+    is_rework = bool(review_feedback)
+
+    if is_rework:
+        branch_instruction = (
+            f"2. Set up the branch:\n"
+            f"   git fetch origin\n"
+            f"   git checkout factory/{subtask['id']} 2>/dev/null || git checkout -b factory/{subtask['id']} origin/{base_branch}\n"
+            f"   (This is a REWORK iteration — you must apply the fixes below before pushing.)\n"
+        )
+        rework_section = (
+            f"\n## ⚠️ REWORK REQUIRED — Previous review feedback\n\n"
+            f"{review_feedback}\n\n"
+            f"Apply these changes on top of the existing branch, then push and update the PR.\n"
+        )
+    else:
+        branch_instruction = (
+            f"2. Set up the branch (handles both fresh start and interrupted-run resume):\n"
+            f"   git fetch origin\n"
+            f"   git checkout factory/{subtask['id']} 2>/dev/null || git checkout -b factory/{subtask['id']} origin/{base_branch}\n"
+            f"   (If the branch already exists from a previous interrupted run, check out the existing branch.\n"
+            f"    Then check if there is already an open PR for this branch: gh pr list --head factory/{subtask['id']} --json number,url\n"
+            f"    If an open PR exists and this is NOT a rework, skip straight to step 9 and print its URL.)\n"
+        )
+        rework_section = ""
+
     task_prompt = (
         f"You are working on the MeshWiki project (FastAPI + Python 3.12 + Rust graph engine). "
         f"Implement the following task and open a GitHub PR when done.\n\n"
         f"## Task: {subtask['title']}\n\n"
-        f"{page_content}\n\n"
+        f"{page_content}\n"
+        f"{rework_section}\n"
         f"## Instructions\n"
         f"1. Explore the codebase to understand context\n"
-        f"2. Set up the branch (handles both fresh start and interrupted-run resume):\n"
-        f"   git fetch origin\n"
-        f"   git checkout factory/{subtask['id']} 2>/dev/null || git checkout -b factory/{subtask['id']} origin/{base_branch}\n"
-        f"   (If the branch already exists from a previous interrupted run, check out the existing branch.\n"
-        f"    Then check if there is already an open PR for this branch: gh pr list --head factory/{subtask['id']} --json number,url\n"
-        f"    If an open PR exists, skip straight to step 9 and print its URL.)\n"
+        f"{branch_instruction}"
         f"3. Implement the changes with tests\n"
         f"4. Run: .venv/bin/black src/ && .venv/bin/isort --profile black src/ && .venv/bin/ruff check src/\n"
         f"5. Run: python -m pytest src/tests/ -x -q\n"
@@ -517,7 +539,8 @@ async def grind_subtask_e2b(
         f"8. Rebase onto the latest {base_branch} to avoid merge conflicts:\n"
         f"   git fetch origin && git rebase origin/{base_branch}\n"
         f"   Resolve any conflicts, then: git push --force-with-lease\n"
-        f"9. Create a PR targeting {base_branch}: gh pr create --base {base_branch} --title '[Factory] ...' --body '...'\n"
+        f"9. {'Update the existing PR' if is_rework else 'Create a PR'} targeting {base_branch}: "
+        f"{'gh pr view --json url --jq .url  # print existing PR URL' if is_rework else f'gh pr create --base {base_branch} --title \"[Factory] ...\" --body \"...\"'}\n"
         f"   The PR title MUST start with '[Factory] ' so it is clearly identified as automated.\n"
         f"10. Print the PR URL on the last line of your output"
     )
@@ -586,7 +609,9 @@ async def grind_subtask_e2b(
 
         # Clone repo (shallow clone of the base branch so grinders start from the latest work)
         repo = settings.github_repo
-        clone_url = f"https://x-access-token:{settings.github_token}@github.com/{repo}.git"
+        clone_url = (
+            f"https://x-access-token:{settings.github_token}@github.com/{repo}.git"
+        )
         result = await sbx.commands.run(
             f"git clone --branch {base_branch} {clone_url} /tmp/repo",
             timeout=0,
@@ -627,7 +652,7 @@ async def grind_subtask_e2b(
 
         # Run Kilo then exit bash so pty_handle.wait() returns.
         kilo_cmd = (
-            f'cd /tmp/repo && kilo run --auto --model {model_arg}'
+            f"cd /tmp/repo && kilo run --auto --model {model_arg}"
             f' "$(cat /tmp/task.md)" ; exit\n'
         )
         await sbx.pty.send_stdin(pid, kilo_cmd.encode())

--- a/orchestrator/factory/webhook_server.py
+++ b/orchestrator/factory/webhook_server.py
@@ -61,11 +61,7 @@ async def _resume_interrupted_tasks(graph, saver, settings) -> None:
             logger.info("factory: no checkpoint for %s — skipping resume", page_name)
             continue
 
-        logger.info(
-            "factory: resuming interrupted task %s from checkpoint (next nodes: %s)",
-            page_name,
-            checkpoint_tuple.next,
-        )
+        logger.info("factory: resuming interrupted task %s from checkpoint", page_name)
 
         def _log_exc(t: asyncio.Task, name: str = page_name) -> None:
             if not t.cancelled() and (exc := t.exception()):


### PR DESCRIPTION
## Summary

Root cause of the **infinite PM review loop**: when PM requests changes, the grinder never saw the feedback and would:
1. Check out the existing branch
2. See an open PR → skip to step 9 → print the URL without making changes
3. PM reviews the same unchanged code → requests the same changes → repeat forever

## Fix

Detect rework iterations via `subtask["review_feedback"]` (set by `pm_review_node` when changes are requested):

- **Rework prompt**: injects the PM feedback as a `## ⚠️ REWORK REQUIRED` section
- **Rework step 2**: removes the "skip to step 9" shortcut — grinder must apply fixes
- **Rework step 9**: uses `gh pr view` to print the existing PR URL instead of creating a new one

The "skip to step 9" shortcut is preserved for interrupted-run resumes (no review_feedback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)