### PR TITLE
[Factory] Improve factory task visibility in the wiki

### DIFF
--- a/orchestrator/factory/integrations/meshwiki_client.py
+++ b/orchestrator/factory/integrations/meshwiki_client.py
@@ -117,3 +117,17 @@ class MeshWikiClient:
             resp = await client.get(url, headers=self._headers(), params=params)
             resp.raise_for_status()
             return resp.json()
+
+    async def append_to_page(self, page_name: str, content_to_append: str) -> None:
+        """
+        Append content_to_append to the body of the named wiki page.
+
+        Gets the current page content, strips trailing whitespace, appends
+        "\\n\\n" + content_to_append, then PUTs the updated content back.
+        """
+        page = await self.get_page(page_name)
+        if page is None:
+            raise ValueError(f"Page not found: {page_name!r}")
+        current_content = page.get("content", "")
+        new_content = current_content.rstrip() + "\n\n" + content_to_append
+        await self.create_page(page_name, new_content)

--- a/orchestrator/factory/nodes/pm_review.py
+++ b/orchestrator/factory/nodes/pm_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 
 from ..agents.pm_agent import review_with_pm
 from ..config import get_settings
@@ -64,13 +65,23 @@ async def pm_review_node(state: FactoryState) -> dict:
 
         if decision == "approved":
             if get_settings().auto_merge and subtask.get("pr_url"):
-                pr_number = subtask.get("pr_number") or _extract_pr_number(subtask["pr_url"])
+                pr_number = subtask.get("pr_number") or _extract_pr_number(
+                    subtask["pr_url"]
+                )
                 if pr_number:
                     try:
                         await github_client.merge_pr(pr_number)
-                        logger.info("pm_review: auto-merged PR #%d for subtask %s", pr_number, subtask["id"])
+                        logger.info(
+                            "pm_review: auto-merged PR #%d for subtask %s",
+                            pr_number,
+                            subtask["id"],
+                        )
                     except Exception as exc:
-                        logger.warning("pm_review: auto-merge failed for PR #%d: %s", pr_number, exc)
+                        logger.warning(
+                            "pm_review: auto-merge failed for PR #%d: %s",
+                            pr_number,
+                            exc,
+                        )
             updated_subtask = SubTask(
                 **{**subtask, "status": "merged", "review_feedback": feedback}
             )
@@ -88,5 +99,37 @@ async def pm_review_node(state: FactoryState) -> dict:
             )
 
         updated_subtasks.append(updated_subtask)
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
+
+        if decision == "approved":
+            pm_section = (
+                f"## PM Review — {timestamp}\n\n"
+                f"✅ **Approved**\n\n"
+                f"{feedback or 'Looks good.'}\n"
+            )
+        else:
+            pm_section = (
+                f"## PM Review — {timestamp}\n\n"
+                f"❌ **Changes requested**\n\n"
+                f"{feedback or 'See comments above.'}\n"
+            )
+
+        try:
+            await meshwiki_client.append_to_page(subtask["wiki_page"], pm_section)
+        except Exception as exc:
+            logger.warning("pm_review: failed to append review to wiki: %s", exc)
+
+        if decision != "approved":
+            try:
+                await meshwiki_client.transition_task(
+                    subtask["wiki_page"], "in_progress"
+                )
+            except Exception as exc:
+                logger.warning(
+                    "pm_review: failed to transition %s back to in_progress: %s",
+                    subtask["wiki_page"],
+                    exc,
+                )
 
     return {"subtasks": updated_subtasks}

--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -615,16 +615,38 @@ def _render_task_status(page_name: str, page_metadata: dict) -> str:
         else ""
     )
 
-    # ── Section D: live terminal (in_progress only) ───────────────────────────
+    # ── Section C2: phase indicator (in_progress / review only) ───────────────
+    phase_html = ""
+    if status in ("in_progress", "review"):
+        pr_url = _get_meta_str(page_metadata, "pr_url")
+        pr_display = ""
+        if pr_url:
+            pr_num_match = re.search(r"/pull/(\d+)", pr_url)
+            if pr_num_match:
+                pr_num = pr_num_match.group(1)
+                pr_display = f' on <a href="{html_escape(pr_url)}" target="_blank" rel="noopener">PR #{html_escape(pr_num)}</a>'
+        if status == "in_progress":
+            if pr_url:
+                phase_text = f"🔨 Grinding — rework in progress{pr_display}"
+            else:
+                phase_text = "🔨 Grinding — grinder is implementing..."
+        elif status == "review":
+            if pr_url:
+                phase_text = f"🔍 PM reviewing{pr_display}..."
+            else:
+                phase_text = "🔍 PM reviewing..."
+        phase_html = f'<div class="task-status-phase">{phase_text}</div>'
+
+    # ── Section D: live terminal (in_progress / review) ──────────────────────
     terminal_html = ""
-    if status == "in_progress":
+    if status in ("in_progress", "review"):
         safe_id = re.sub(r"[^a-zA-Z0-9-]", "-", page_name)
-        # Escape < > so the JSON string is safe inside a <script> tag.
         page_name_js = (
             json.dumps(page_name).replace("<", "\\u003c").replace(">", "\\u003e")
         )
+        is_done_status = status in ("merged", "done", "failed", "rejected")
         terminal_html = (
-            '<div class="task-status-terminal">'
+            f'<div class="task-status-terminal"{" data-terminal-done" if is_done_status else ""}>'
             '<div class="task-terminal-header">'
             '<span class="task-terminal-dot task-terminal-dot--red"></span>'
             '<span class="task-terminal-dot task-terminal-dot--yellow"></span>'
@@ -637,6 +659,8 @@ def _render_task_status(page_name: str, page_metadata: dict) -> str:
             "(function(){"
             f"var PAGE={page_name_js};"
             f"var EL=document.getElementById('task-terminal-{safe_id}');"
+            f"var DONE={str(is_done_status).lower()};"
+            "var NO_SESSION_MSG='\\r\\n\\x1b[2m[no active terminal session for this task]\\x1b[0m\\r\\n';"
             "function boot(){"
             "var t=new Terminal({"
             "cols:220,rows:50,disableStdin:true,convertEol:true,scrollback:5000,"
@@ -645,10 +669,43 @@ def _render_task_status(page_name: str, page_metadata: dict) -> str:
             "});"
             "t.open(EL);"
             "var pr=location.protocol==='https:'?'wss:':'ws:';"
+            "var retries=0;"
+            "var retryMax=10;"
+            "var retryDelay=5000;"
+            "var bannerEl=null;"
+            "function showBanner(msg){"
+            "bannerEl=document.createElement('div');"
+            "bannerEl.style.cssText='position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);"
+            "color:#888;font-family:Menlo,Monaco,monospace;font-size:13px;text-align:center;"
+            "pointer-events:none;';"
+            "bannerEl.textContent=msg;"
+            "EL.style.position='relative';EL.appendChild(bannerEl);"
+            "}"
+            "function clearBanner(){if(bannerEl&&bannerEl.parentNode){bannerEl.parentNode.removeChild(bannerEl);bannerEl=null;}}"
+            "function connect(){"
             "var ws=new WebSocket(pr+'//'+location.host+'/ws/terminal/'+PAGE);"
-            "ws.onmessage=function(e){t.write(e.data);};"
-            "ws.onclose=function(){t.write('\\r\\n\\x1b[2m\\u2501\\u2501\\u2501 session ended \\u2501\\u2501\\u2501\\x1b[0m\\r\\n');};"
+            "ws.onmessage=function(e){"
+            "if(e.data===NO_SESSION_MSG.trim()){"
+            "if(!bannerEl){showBanner('[session ended — waiting for next grinder run...]');}"
+            "}else{"
+            "clearBanner();"
+            "if(e.data!==NO_SESSION_MSG){t.write(e.data);}"
+            "}"
+            "};"
+            "ws.onclose=function(e){"
+            "if(DONE||e.code===1000){t.write('\\r\\n\\x1b[2m\\u2501\\u2501\\u2501 session ended \\u2501\\u2501\\u2501\\x1b[0m\\r\\n');return;}"
+            "clearBanner();"
+            "if(retries<retryMax){"
+            "retries++;"
+            "showBanner('[session ended — waiting for next grinder run...]');"
+            "setTimeout(connect,retryDelay);"
+            "}else{"
+            "showBanner('[no more retries — reload page]');"
+            "}"
+            "};"
             "ws.onerror=function(){t.write('\\r\\n\\x1b[31m[connection error]\\x1b[0m\\r\\n');};"
+            "};"
+            "connect();"
             "}"
             "if(window.Terminal){boot();}"
             "else{"
@@ -668,6 +725,7 @@ def _render_task_status(page_name: str, page_metadata: dict) -> str:
         f"{badge_html}"
         f"{diagram_html}"
         f"{meta_html}"
+        f"{phase_html}"
         f"{terminal_html}"
         "</div>"
     )

--- a/src/meshwiki/core/task_machine.py
+++ b/src/meshwiki/core/task_machine.py
@@ -21,7 +21,7 @@ TASK_TRANSITIONS: dict[str, list[str]] = {
     "decomposed": ["approved", "planned", "blocked"],
     "approved": ["in_progress", "blocked"],
     "in_progress": ["review", "failed", "blocked"],
-    "review": ["merged", "rejected", "blocked"],
+    "review": ["merged", "rejected", "in_progress", "blocked"],
     "merged": ["done"],
     "done": [],
     "failed": ["planned", "blocked"],
@@ -37,6 +37,7 @@ CANONICAL_EVENTS: dict[tuple[str, str], str] = {
     ("in_progress", "review"): "task.pr_created",
     ("review", "merged"): "task.pr_merged",
     ("review", "rejected"): "task.pr_rejected",
+    ("review", "in_progress"): "task.rework",
     ("merged", "done"): "task.completed",
     ("planned", "in_progress"): "task.assigned",  # direct grind (no PM decomposition)
 }

--- a/src/meshwiki/static/css/style.css
+++ b/src/meshwiki/static/css/style.css
@@ -1823,6 +1823,21 @@ article.page > .breadcrumb {
     padding-top: 0.75rem;
 }
 
+/* Phase indicator */
+.task-status-phase {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #666);
+    padding: 4px 8px;
+    margin-bottom: 4px;
+    background: var(--surface-secondary, #f5f5f5);
+    border-radius: 4px;
+    font-family: var(--font-mono, monospace);
+}
+[data-theme="dark"] .task-status-phase {
+    background: #2a2a2a;
+    color: #ccc;
+}
+
 .task-meta-item {
     display: flex;
     align-items: center;

--- a/src/tests/test_task_status_macro.py
+++ b/src/tests/test_task_status_macro.py
@@ -254,7 +254,7 @@ class TestTerminalSection:
 
     def test_terminal_absent_for_review(self):
         html = render("<<TaskStatus>>", metadata={"type": "task", "status": "review"})
-        assert "task-status-terminal" not in html
+        assert "task-status-terminal" in html
 
     def test_page_name_xss_safe(self):
         """page_name is embedded via json.dumps — angle brackets must be escaped."""
@@ -264,6 +264,76 @@ class TestTerminalSection:
             metadata={"type": "task", "status": "in_progress"},
         )
         assert "<script>alert(1)</script>" not in html
+
+
+# ============================================================
+# Phase indicator
+# ============================================================
+
+
+class TestPhaseIndicator:
+    def test_phase_absent_for_draft(self):
+        html = render("<<TaskStatus>>", metadata={"type": "task", "status": "draft"})
+        assert "task-status-phase" not in html
+
+    def test_phase_absent_for_done(self):
+        html = render("<<TaskStatus>>", metadata={"type": "task", "status": "done"})
+        assert "task-status-phase" not in html
+
+    def test_phase_absent_for_failed(self):
+        html = render("<<TaskStatus>>", metadata={"type": "task", "status": "failed"})
+        assert "task-status-phase" not in html
+
+    def test_phase_absent_for_merged(self):
+        html = render("<<TaskStatus>>", metadata={"type": "task", "status": "merged"})
+        assert "task-status-phase" not in html
+
+    def test_phase_absent_for_rejected(self):
+        html = render("<<TaskStatus>>", metadata={"type": "task", "status": "rejected"})
+        assert "task-status-phase" not in html
+
+    def test_phase_grinding_no_pr(self):
+        html = render(
+            "<<TaskStatus>>", metadata={"type": "task", "status": "in_progress"}
+        )
+        assert "task-status-phase" in html
+        assert "🔨 Grinding" in html
+        assert "grinder is implementing" in html
+
+    def test_phase_grinding_with_pr(self):
+        html = render(
+            "<<TaskStatus>>",
+            metadata={
+                "type": "task",
+                "status": "in_progress",
+                "pr_url": "https://github.com/org/repo/pull/123",
+            },
+        )
+        assert "task-status-phase" in html
+        assert "🔨 Grinding" in html
+        assert "rework in progress" in html
+        assert 'href="https://github.com/org/repo/pull/123"' in html
+        assert "PR #123" in html
+
+    def test_phase_reviewing_no_pr(self):
+        html = render("<<TaskStatus>>", metadata={"type": "task", "status": "review"})
+        assert "task-status-phase" in html
+        assert "🔍 PM reviewing" in html
+        assert "task is complete" not in html
+
+    def test_phase_reviewing_with_pr(self):
+        html = render(
+            "<<TaskStatus>>",
+            metadata={
+                "type": "task",
+                "status": "review",
+                "pr_url": "https://github.com/org/repo/pull/456",
+            },
+        )
+        assert "task-status-phase" in html
+        assert "🔍 PM reviewing" in html
+        assert 'href="https://github.com/org/repo/pull/456"' in html
+        assert "PR #456" in html
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Show terminal section for `review` status (was only `in_progress`)
- Add WebSocket reconnection logic with 5s retry, up to 10 attempts
- Add phase indicator between metadata and terminal sections showing current grinding/review state
- Add `append_to_page()` method to `MeshWikiClient` for appending content to wiki pages
- Log PM review decisions (approved/changes requested) to wiki page after each decision
- Transition task back to `in_progress` when PM requests changes (rework)
- Add `task.rework` canonical event for `review->in_progress` transition
- Add CSS for `.task-status-phase`

## Changes
- `src/meshwiki/core/parser.py`: Terminal now renders for `review` status, phase indicator added, WebSocket reconnection logic
- `src/meshwiki/core/task_machine.py`: Added `("review", "in_progress"): "task.rework"` canonical event
- `src/meshwiki/static/css/style.css`: Added `.task-status-phase` styles
- `src/tests/test_task_status_macro.py`: Updated tests and added phase indicator tests
- `orchestrator/factory/integrations/meshwiki_client.py`: Added `append_to_page()` method
- `orchestrator/factory/nodes/pm_review.py`: Added PM review logging and rework transition

## Testing
- All 398 tests pass in `src/tests/`
- Lint checks pass

Closes Factory/TASK004-Improve-Factory-Visibility