### PR TITLE
[Factory] Add PageList macro

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1,5 +1,6 @@
 """Markdown parser with wiki link support."""
 
+import asyncio
 import json
 import re
 from datetime import datetime, timezone
@@ -787,6 +788,137 @@ class TaskStatusExtension(Extension):
         )
 
 
+PAGELIST_PATTERN = re.compile(r"<<PageList(?:\(([^)]*)\))?>>")
+
+
+def _parse_pagelist_args(args_str: str | None) -> dict[str, str]:
+    """Parse comma-separated key=value pairs from a macro argument string.
+
+    Returns a dict of lowercased keys to raw string values.
+    Empty or None input returns {}.
+    """
+    if not args_str:
+        return {}
+    result = {}
+    for part in args_str.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" in part:
+            key, value = part.split("=", 1)
+            result[key.strip().lower()] = value.strip()
+    return result
+
+
+def _render_page_list(args_str: str | None) -> str:
+    """Render <<PageList(...)>> as an HTML list of wiki pages."""
+    from meshwiki.core.dependencies import get_storage
+
+    args = _parse_pagelist_args(args_str)
+
+    try:
+        storage = get_storage()
+    except RuntimeError:
+        return (
+            '<div class="page-list-wrapper">'
+            '<p class="page-list-unavailable">'
+            "<em>PageList: storage not available</em></p></div>"
+        )
+
+    try:
+        if "tag" in args:
+            pages = asyncio.run(storage.search_by_tag(args["tag"]))
+        else:
+            pages = asyncio.run(storage.list_pages_with_metadata())
+    except Exception:
+        return (
+            '<div class="page-list-wrapper">'
+            '<p class="page-list-unavailable">'
+            "<em>PageList: storage not available</em></p></div>"
+        )
+
+    if "prefix" in args:
+        prefix = args["prefix"]
+        pages = [p for p in pages if p.name.startswith(prefix)]
+
+    pages.sort(key=lambda p: p.name.lower())
+
+    if "limit" in args:
+        try:
+            limit = int(args["limit"])
+            if limit > 0:
+                pages = pages[:limit]
+        except ValueError:
+            pass
+
+    if not pages:
+        return (
+            '<div class="page-list-wrapper">'
+            '<p class="page-list-empty"><em>No pages found</em></p></div>'
+        )
+
+    lines = ['<div class="page-list-wrapper">', '<ul class="page-list">']
+    for page in pages:
+        url_name = page.name.replace(" ", "_")
+        tags_html = ""
+        if page.metadata.tags:
+            tag_links = [
+                f'<a href="/search?tag={html_escape(t)}" class="tag-pill">{html_escape(t)}</a>'
+                for t in page.metadata.tags
+            ]
+            tags_html = f'<span class="page-list-tags">{"".join(tag_links)}</span>'
+        lines.append(
+            f'<li class="page-list-item">'
+            f'<a href="/page/{url_name}" class="wiki-link">{html_escape(page.name)}</a>'
+            f"{tags_html}"
+            f"</li>"
+        )
+    lines.append("</ul></div>")
+    return "\n".join(lines)
+
+
+class PageListPreprocessor(Preprocessor):
+    """Preprocessor that replaces <<PageList(...)>> macros with an HTML list."""
+
+    def run(self, lines: list[str]) -> list[str]:
+        text = "\n".join(lines)
+        if "<<PageList" not in text:
+            return lines
+
+        code_block_re = re.compile(r"(```.*?```|~~~.*?~~~)", re.DOTALL)
+        code_blocks: list[str] = []
+
+        def stash_code(m: re.Match) -> str:
+            placeholder = f"\x00PLBLOCK{len(code_blocks)}\x00"
+            code_blocks.append(m.group(0))
+            return placeholder
+
+        text = code_block_re.sub(stash_code, text)
+
+        def replace_match(m: re.Match) -> str:
+            args_str = m.group(1)
+            html = _render_page_list(args_str)
+            return self.md.htmlStash.store(html)
+
+        text = PAGELIST_PATTERN.sub(replace_match, text)
+
+        for i, block in enumerate(code_blocks):
+            text = text.replace(f"\x00PLBLOCK{i}\x00", block)
+
+        return text.split("\n")
+
+
+class PageListExtension(Extension):
+    """Markdown extension for <<PageList(...)>> macros."""
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            PageListPreprocessor(md),
+            "pagelist",
+            28,
+        )
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # BackLinks macro
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1070,6 +1202,7 @@ def create_parser(
             RecentChangesExtension(recent_pages=recent_pages),  # <<RecentChanges(n)>>
             PageCountExtension(),  # <<PageCount>>
             BackLinksExtension(page_name=page_name),  # <<BackLinks>>
+            PageListExtension(),  # <<PageList(...)>>
         ]
     )
 

--- a/src/meshwiki/static/css/style.css
+++ b/src/meshwiki/static/css/style.css
@@ -1943,3 +1943,17 @@ article.page > .breadcrumb {
     height: 100%;
     padding: 0.5rem;
 }
+
+/* PageList macro */
+.page-list-wrapper { margin: 1rem 0; }
+.page-list { list-style: none; padding: 0; margin: 0; }
+.page-list-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0;
+    border-bottom: 1px solid var(--color-border, #eee);
+}
+.page-list-item:last-child { border-bottom: none; }
+.page-list-tags { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+.page-list-empty, .page-list-unavailable { color: var(--color-text-muted, #888); font-style: italic; }

--- a/src/tests/test_page_list_macro.py
+++ b/src/tests/test_page_list_macro.py
@@ -1,0 +1,199 @@
+"""Unit tests for the <<PageList>> macro."""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from meshwiki.core.models import Page, PageMetadata
+from meshwiki.core.parser import parse_wiki_content
+
+
+def make_page(
+    name: str,
+    tags: list[str] | None = None,
+    created_minutes_ago: int = 60,
+    modified_minutes_ago: int = 60,
+) -> Page:
+    """Create a mock page."""
+    created = datetime.now() - timedelta(minutes=created_minutes_ago)
+    modified = datetime.now() - timedelta(minutes=modified_minutes_ago)
+    metadata = PageMetadata(
+        tags=tags or [],
+        created=created,
+        modified=modified,
+    )
+    return Page(
+        name=name,
+        content="# " + name,
+        metadata=metadata,
+        exists=True,
+    )
+
+
+def render(text: str, pages: list[Page] | None = None) -> str:
+    """Render text through the parser, patching get_storage."""
+    if pages is None:
+        pages = []
+
+    mock_storage = MagicMock()
+
+    async def mock_list_pages_with_metadata() -> list[Page]:
+        return pages
+
+    async def mock_search_by_tag(tag: str) -> list[Page]:
+        return [p for p in pages if tag.lower() in [t.lower() for t in p.metadata.tags]]
+
+    mock_storage.list_pages_with_metadata = mock_list_pages_with_metadata
+    mock_storage.search_by_tag = mock_search_by_tag
+
+    with patch("meshwiki.core.dependencies.get_storage", return_value=mock_storage):
+        html = parse_wiki_content(text)
+    return html
+
+
+class TestPageListBasic:
+    """Basic rendering tests."""
+
+    def test_renders_all_pages(self):
+        """<<PageList>> renders links to all pages."""
+        pages = [
+            make_page("Page A"),
+            make_page("Page B"),
+            make_page("Page C"),
+        ]
+        html = render("<<PageList>>", pages=pages)
+        assert "page-list-wrapper" in html
+        assert "page-list" in html
+        assert "Page A" in html
+        assert "Page B" in html
+        assert "Page C" in html
+
+    def test_wiki_link_for_each_page(self):
+        """Each entry is a wiki link to the page."""
+        pages = [make_page("TestPage")]
+        html = render("<<PageList>>", pages=pages)
+        assert 'href="/page/TestPage"' in html
+        assert 'class="wiki-link">TestPage</a>' in html
+
+    def test_page_name_with_spaces(self):
+        """Page names with spaces are properly linked."""
+        pages = [make_page("My Page Name")]
+        html = render("<<PageList>>", pages=pages)
+        assert 'href="/page/My_Page_Name"' in html
+
+
+class TestPageListFiltering:
+    """Tests for tag, prefix, and limit filtering."""
+
+    def test_tag_filter(self):
+        """<<PageList(tag=foo)>> only shows pages with tag 'foo'."""
+        pages = [
+            make_page("Page With Foo", tags=["foo"]),
+            make_page("Page Without Tag", tags=[]),
+            make_page("Another With Foo", tags=["foo", "bar"]),
+        ]
+        html = render("<<PageList(tag=foo)>>", pages=pages)
+        assert "Page With Foo" in html
+        assert "Another With Foo" in html
+        assert "Page Without Tag" not in html
+
+    def test_prefix_filter(self):
+        """<<PageList(prefix=Docs/)>> only shows pages starting with 'Docs/'."""
+        pages = [
+            make_page("Docs/Introduction"),
+            make_page("Docs/Getting Started"),
+            make_page("Blog/First Post"),
+            make_page("Other"),
+        ]
+        html = render("<<PageList(prefix=Docs/)>>", pages=pages)
+        assert "Docs/Introduction" in html
+        assert "Docs/Getting Started" in html
+        assert "Blog/First Post" not in html
+        assert "Other" not in html
+
+    def test_limit(self):
+        """<<PageList(limit=2)>> with 5 pages returns only 2."""
+        pages = [make_page(f"Page {i}") for i in range(5)]
+        html = render("<<PageList(limit=2)>>", pages=pages)
+        count = html.count("page-list-item")
+        assert count == 2
+
+    def test_combined_args(self):
+        """<<PageList(tag=foo, limit=1)>> with 3 tagged pages returns 1."""
+        pages = [
+            make_page("Page A", tags=["foo"]),
+            make_page("Page B", tags=["foo"]),
+            make_page("Page C", tags=["foo"]),
+            make_page("Page D", tags=["bar"]),
+        ]
+        html = render("<<PageList(tag=foo, limit=1)>>", pages=pages)
+        count = html.count("page-list-item")
+        assert count == 1
+
+
+class TestPageListSorting:
+    """Tests for alphabetical sorting."""
+
+    def test_alphabetical_order(self):
+        """Pages are sorted case-insensitively by name."""
+        pages = [
+            make_page("Zebra"),
+            make_page("apple"),
+            make_page("Banana"),
+        ]
+        html = render("<<PageList>>", pages=pages)
+        apple_idx = html.find("apple")
+        banana_idx = html.find("Banana")
+        zebra_idx = html.find("Zebra")
+        assert apple_idx < banana_idx < zebra_idx
+
+
+class TestPageListEdgeCases:
+    """Edge case handling."""
+
+    def test_empty_result(self):
+        """<<PageList>> when storage returns [] shows empty message."""
+        html = render("<<PageList>>", pages=[])
+        assert "page-list-empty" in html
+        assert "No pages found" in html
+
+    def test_storage_unavailable(self):
+        """<<PageList>> when get_storage raises RuntimeError shows unavailable message."""
+        with patch(
+            "meshwiki.core.dependencies.get_storage",
+            side_effect=RuntimeError("Storage not initialised"),
+        ):
+            html = parse_wiki_content("<<PageList>>")
+        assert "page-list-unavailable" in html
+        assert "PageList: storage not available" in html
+
+    def test_not_replaced_in_fenced_code_block(self):
+        """<<PageList>> inside code blocks is escaped, not rendered."""
+        content = "```\n<<PageList>>\n```"
+        html = render(content, pages=[make_page("Test")])
+        assert "page-list-wrapper" not in html
+        assert "&lt;&lt;PageList&gt;&gt;" in html
+
+    def test_not_replaced_in_tilde_code_block(self):
+        """<<PageList>> inside ~~~ code blocks is escaped, not rendered."""
+        content = "~~~\n<<PageList>>\n~~~"
+        html = render(content, pages=[make_page("Test")])
+        assert "page-list-wrapper" not in html
+
+
+class TestPageListTags:
+    """Tests for tag display."""
+
+    def test_tags_displayed(self):
+        """Page with tags shows tag pills as links."""
+        pages = [make_page("TaggedPage", tags=["foo", "bar"])]
+        html = render("<<PageList>>", pages=pages)
+        assert "page-list-tags" in html
+        assert 'href="/search?tag=foo"' in html
+        assert 'href="/search?tag=bar"' in html
+        assert "tag-pill" in html
+
+    def test_no_tags_no_span(self):
+        """Page without tags has no .page-list-tags span."""
+        pages = [make_page("NoTagsPage", tags=[])]
+        html = render("<<PageList>>", pages=pages)
+        assert "page-list-tags" not in html


### PR DESCRIPTION
## Summary
- Add `<<PageList>>` macro supporting `tag=`, `prefix=`, and `limit=` arguments
- Renders alphabetically sorted list of wiki pages with tag pills
- Follows existing macro patterns (RecentChanges, PageCount, BackLinks)
- Includes 14 unit tests covering all filtering modes and edge cases

## Changes
- `src/meshwiki/core/parser.py`: PageList preprocessor/extension and render function
- `src/meshwiki/static/css/style.css`: CSS styles for `.page-list-*` elements
- `src/tests/test_page_list_macro.py`: 14 unit tests

## Testing
- All 414 tests pass (32 skipped)
- Lint checks pass (black, isort, ruff)