### PR TITLE
fix: correct Anthropic key preservation in CI env write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,9 +435,12 @@ jobs:
             if grep -q FACTORY_ANTHROPIC_API_KEY /opt/meshwiki/orchestrator-staging.env.new; then
               mv /opt/meshwiki/orchestrator-staging.env.new /opt/meshwiki/orchestrator-staging.env
             else
-              grep -v '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator-staging.env > /opt/meshwiki/orchestrator-staging.env.tmp 2>/dev/null || true
-              cat /opt/meshwiki/orchestrator-staging.env.new >> /opt/meshwiki/orchestrator-staging.env.tmp
-              mv /opt/meshwiki/orchestrator-staging.env.tmp /opt/meshwiki/orchestrator-staging.env
+              SAVED_KEY=\$(grep '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator-staging.env 2>/dev/null || true)
+              if [ -n \"\$SAVED_KEY\" ]; then
+                { cat /opt/meshwiki/orchestrator-staging.env.new; echo \"\$SAVED_KEY\"; } > /opt/meshwiki/orchestrator-staging.env
+              else
+                mv /opt/meshwiki/orchestrator-staging.env.new /opt/meshwiki/orchestrator-staging.env
+              fi
               rm -f /opt/meshwiki/orchestrator-staging.env.new
             fi
           "
@@ -570,9 +573,12 @@ jobs:
             if grep -q FACTORY_ANTHROPIC_API_KEY /opt/meshwiki/orchestrator.env.new; then
               mv /opt/meshwiki/orchestrator.env.new /opt/meshwiki/orchestrator.env
             else
-              grep -v '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator.env > /opt/meshwiki/orchestrator.env.tmp 2>/dev/null || true
-              cat /opt/meshwiki/orchestrator.env.new >> /opt/meshwiki/orchestrator.env.tmp
-              mv /opt/meshwiki/orchestrator.env.tmp /opt/meshwiki/orchestrator.env
+              SAVED_KEY=\$(grep '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator.env 2>/dev/null || true)
+              if [ -n \"\$SAVED_KEY\" ]; then
+                { cat /opt/meshwiki/orchestrator.env.new; echo \"\$SAVED_KEY\"; } > /opt/meshwiki/orchestrator.env
+              else
+                mv /opt/meshwiki/orchestrator.env.new /opt/meshwiki/orchestrator.env
+              fi
               rm -f /opt/meshwiki/orchestrator.env.new
             fi
           "


### PR DESCRIPTION
Fixes a bug in the previous attempt (PR #99): when the GitHub secret is empty, the old logic appended all old env vars before the new ones, duplicating every variable while still losing the key.

Corrected: write the new vars, then append only the saved `FACTORY_ANTHROPIC_API_KEY` line from the existing file.

Key is confirmed working (HTTP 200 from api.anthropic.com) on the VPS with the value currently in the env file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)