### PR TITLE
[Factory] Include Macro - Fixes for issues 2, 3, and minor heading default

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1043,15 +1043,8 @@ def _parse_include_args(
     if sort_match:
         sort = sort_match.group(1) or None
 
-    named_part_end = max(
-        from_match.end() if from_match else 0,
-        to_match.end() if to_match else 0,
-        sort_match.end() if sort_match else 0,
-    )
-    if named_part_end > 0:
-        args_str = args_str[:named_part_end]
-
-    positional = [s.strip() for s in args_str.split(",")]
+    clean = re.sub(r'\b(?:from|to|sort)=(?:"[^"]*"|\S+)', "", args_str)
+    positional = [s.strip() for s in clean.split(",")]
     if len(positional) >= 1:
         page_name = positional[0]
     if len(positional) >= 2 and positional[1]:
@@ -1118,8 +1111,8 @@ def _render_include(
     if heading_text is None and heading_level is not None:
         heading_text = page_name
 
-    if heading_text and heading_level:
-        level = max(1, min(6, heading_level))
+    if heading_text:
+        level = max(1, min(6, heading_level if heading_level is not None else 2))
         content = f"<h{level}>{html_escape(heading_text)}</h{level}>\n{content}"
 
     nested_html = parse_wiki_content(

--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1008,6 +1008,241 @@ class BackLinksExtension(Extension):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Include macro
+# ─────────────────────────────────────────────────────────────────────────────
+
+INCLUDE_PATTERN = re.compile(
+    r"<<Include\(\s*(.+?)\s*\)>>",
+    re.DOTALL,
+)
+
+
+def _parse_include_args(
+    args_str: str,
+) -> tuple[str, str | None, int | None, str | None, str | None, str | None]:
+    """Parse Include macro arguments.
+
+    Returns:
+        Tuple of (page_name, heading_text, heading_level, from_marker, to_marker, sort).
+    """
+    page_name = args_str.strip()
+    heading_text: str | None = None
+    heading_level: int | None = None
+    from_marker: str | None = None
+    to_marker: str | None = None
+    sort: str | None = None
+
+    from_match = re.search(r'from="([^"]*)"', args_str)
+    to_match = re.search(r'to="([^"]*)"', args_str)
+    sort_match = re.search(r"sort=(ascending|descending)", args_str)
+
+    if from_match:
+        from_marker = from_match.group(1) or None
+    if to_match:
+        to_marker = to_match.group(1) or None
+    if sort_match:
+        sort = sort_match.group(1) or None
+
+    named_part_end = max(
+        from_match.end() if from_match else 0,
+        to_match.end() if to_match else 0,
+        sort_match.end() if sort_match else 0,
+    )
+    if named_part_end > 0:
+        args_str = args_str[:named_part_end]
+
+    positional = [s.strip() for s in args_str.split(",")]
+    if len(positional) >= 1:
+        page_name = positional[0]
+    if len(positional) >= 2 and positional[1]:
+        heading_text = positional[1].strip('"')
+    if len(positional) >= 3 and positional[2]:
+        try:
+            heading_level = int(positional[2])
+        except ValueError:
+            pass
+
+    return page_name, heading_text, heading_level, from_marker, to_marker, sort
+
+
+def _render_include(
+    page_name: str,
+    heading_text: str | None,
+    heading_level: int | None,
+    from_marker: str | None,
+    to_marker: str | None,
+    sort: str | None,
+    page_contents: dict[str, str],
+    include_chain: list[str],
+) -> str:
+    """Render the <<Include(...)>> macro as embedded content HTML."""
+    if page_name.endswith("/*"):
+        prefix = page_name[:-2]
+        matching_pages = sorted(
+            [pn for pn in page_contents if pn.startswith(prefix)],
+            reverse=(sort == "descending"),
+        )
+        if not matching_pages:
+            return f'<span class="include-missing">[[{page_name}]]</span>'
+        parts: list[str] = []
+        for matched_page in matching_pages:
+            content = page_contents.get(matched_page, "")
+            content = _strip_frontmatter(content)
+            nested_html = parse_wiki_content(
+                content,
+                page_contents=page_contents,
+                include_chain=include_chain + [matched_page],
+            )
+            parts.append(
+                f'<div class="include-content" data-included-page="{html_escape(matched_page)}">'
+                f"{nested_html}"
+                f"</div>"
+            )
+        return "\n".join(parts)
+
+    content = page_contents.get(page_name)
+    if content is None:
+        return f'<span class="include-missing">[[{page_name}]]</span>'
+
+    if page_name in include_chain:
+        return (
+            f'<span class="include-circular">[[{page_name}]]'
+            f"<em>(circular include skipped)</em></span>"
+        )
+
+    content = _strip_frontmatter(content)
+
+    if from_marker or to_marker:
+        content = _extract_snippet(content, from_marker, to_marker)
+
+    if heading_text is None and heading_level is not None:
+        heading_text = page_name
+
+    if heading_text and heading_level:
+        level = max(1, min(6, heading_level))
+        content = f"<h{level}>{html_escape(heading_text)}</h{level}>\n{content}"
+
+    nested_html = parse_wiki_content(
+        content,
+        page_contents=page_contents,
+        include_chain=include_chain + [page_name],
+    )
+
+    return (
+        f'<div class="include-content" data-included-page="{html_escape(page_name)}">'
+        f"{nested_html}"
+        f"</div>"
+    )
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Strip YAML frontmatter from content."""
+    return FRONTMATTER_PATTERN.sub("", content)
+
+
+def _extract_snippet(
+    content: str, from_marker: str | None, to_marker: str | None
+) -> str:
+    """Extract snippet between from_marker and to_marker."""
+    if from_marker is None and to_marker is None:
+        return content
+
+    start = 0
+    end = len(content)
+
+    if from_marker:
+        idx = content.find(from_marker)
+        if idx != -1:
+            start = idx + len(from_marker)
+
+    if to_marker:
+        idx = content.find(to_marker, start)
+        if idx != -1:
+            end = idx
+
+    return content[start:end]
+
+
+class IncludePreprocessor(Preprocessor):
+    """Preprocessor that replaces <<Include(...)>> macros with embedded page content."""
+
+    def __init__(
+        self,
+        md: Markdown,
+        page_contents: dict[str, str] | None = None,
+        include_chain: list[str] | None = None,
+    ):
+        super().__init__(md)
+        self.page_contents = page_contents or {}
+        self.include_chain = include_chain or []
+
+    def run(self, lines: list[str]) -> list[str]:
+        text = "\n".join(lines)
+        if "<<Include(" not in text:
+            return lines
+
+        code_block_re = re.compile(r"(```.*?```|~~~.*?~~~)", re.DOTALL)
+        code_blocks: list[str] = []
+
+        def stash_code(m: re.Match) -> str:
+            placeholder = f"\x00INCLBLOCK{len(code_blocks)}\x00"
+            code_blocks.append(m.group(0))
+            return placeholder
+
+        text = code_block_re.sub(stash_code, text)
+
+        def replace_match(m: re.Match) -> str:
+            args_str = m.group(1)
+            (
+                page_name,
+                heading_text,
+                heading_level,
+                from_marker,
+                to_marker,
+                sort,
+            ) = _parse_include_args(args_str)
+            html = _render_include(
+                page_name,
+                heading_text,
+                heading_level,
+                from_marker,
+                to_marker,
+                sort,
+                self.page_contents,
+                self.include_chain,
+            )
+            return self.md.htmlStash.store(html)
+
+        text = INCLUDE_PATTERN.sub(replace_match, text)
+
+        for i, block in enumerate(code_blocks):
+            text = text.replace(f"\x00INCLBLOCK{i}\x00", block)
+
+        return text.split("\n")
+
+
+class IncludeExtension(Extension):
+    """Markdown extension for <<Include(...)>> macros."""
+
+    def __init__(
+        self,
+        page_contents: dict[str, str] | None = None,
+        include_chain: list[str] | None = None,
+        **kwargs,
+    ):
+        self.page_contents = page_contents or {}
+        self.include_chain = include_chain or []
+        super().__init__(**kwargs)
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            IncludePreprocessor(md, self.page_contents, self.include_chain),
+            "include",
+            28,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # EpicStatus macro
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -1173,6 +1408,8 @@ def create_parser(
     page_metadata: dict | None = None,
     recent_pages: list | None = None,
     all_pages: list | None = None,
+    page_contents: dict[str, str] | None = None,
+    include_chain: list[str] | None = None,
 ) -> Markdown:
     """Create a Markdown parser with wiki link support.
 
@@ -1183,6 +1420,8 @@ def create_parser(
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
         recent_pages: List of Page objects for RecentChanges macro.
         all_pages: List of all Page objects for PageList macro.
+        page_contents: Dict mapping page names to raw content for Include macro.
+        include_chain: List of page names in the current include chain (for circular detection).
 
     Returns:
         Configured Markdown parser instance.
@@ -1210,6 +1449,10 @@ def create_parser(
             PageCountExtension(),  # <<PageCount>>
             BackLinksExtension(page_name=page_name),  # <<BackLinks>>
             PageListExtension(all_pages=all_pages),  # <<PageList(...)>>
+            IncludeExtension(
+                page_contents=page_contents or {},
+                include_chain=include_chain or [],
+            ),  # <<Include(...)>>
         ]
     )
 
@@ -1221,6 +1464,8 @@ def parse_wiki_content(
     page_metadata: dict | None = None,
     recent_pages: list | None = None,
     all_pages: list | None = None,
+    page_contents: dict[str, str] | None = None,
+    include_chain: list[str] | None = None,
 ) -> str:
     """Parse wiki content (Markdown + wiki links) to HTML.
 
@@ -1231,6 +1476,8 @@ def parse_wiki_content(
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
         recent_pages: List of Page objects for RecentChanges macro.
         all_pages: List of all Page objects for PageList macro.
+        page_contents: Dict mapping page names to raw content for Include macro.
+        include_chain: List of page names in the current include chain (for circular detection).
 
     Returns:
         HTML string.
@@ -1241,6 +1488,8 @@ def parse_wiki_content(
         page_metadata=page_metadata,
         recent_pages=recent_pages,
         all_pages=all_pages,
+        page_contents=page_contents,
+        include_chain=include_chain or [],
     )
     return parser.convert(content)
 
@@ -1252,6 +1501,8 @@ def parse_wiki_content_with_toc(
     page_metadata: dict | None = None,
     recent_pages: list | None = None,
     all_pages: list | None = None,
+    page_contents: dict[str, str] | None = None,
+    include_chain: list[str] | None = None,
 ) -> tuple[str, str]:
     """Parse wiki content and return HTML with table of contents.
 
@@ -1262,6 +1513,8 @@ def parse_wiki_content_with_toc(
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
         recent_pages: List of Page objects for RecentChanges macro.
         all_pages: List of all Page objects for PageList macro.
+        page_contents: Dict mapping page names to raw content for Include macro.
+        include_chain: List of page names in the current include chain (for circular detection).
 
     Returns:
         Tuple of (html_content, toc_html).
@@ -1272,6 +1525,8 @@ def parse_wiki_content_with_toc(
         page_metadata=page_metadata,
         recent_pages=recent_pages,
         all_pages=all_pages,
+        page_contents=page_contents,
+        include_chain=include_chain or [],
     )
     html = parser.convert(content)
     toc_html = getattr(parser, "toc", "")

--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1079,6 +1079,12 @@ def _render_include(
             return f'<span class="include-missing">[[{page_name}]]</span>'
         parts: list[str] = []
         for matched_page in matching_pages:
+            if matched_page in include_chain:
+                parts.append(
+                    f'<span class="include-circular">[[{matched_page}]]'
+                    f"<em>(circular include skipped)</em></span>"
+                )
+                continue
             content = page_contents.get(matched_page, "")
             content = _strip_frontmatter(content)
             nested_html = parse_wiki_content(

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -422,6 +422,14 @@ async def view_page(request: Request, name: str):
         reverse=True,
     )
 
+    # Fetch all page contents for <<Include>> macro.
+    page_contents: dict[str, str] = {}
+    all_page_names = await storage.list_pages()
+    for page_name in all_page_names:
+        raw = await storage.get_raw_content(page_name)
+        if raw is not None:
+            page_contents[page_name] = raw
+
     # Parse content with wiki links, TOC, and page context for macros.
     html_content, toc_html = parse_wiki_content_with_toc(
         page.content,
@@ -430,6 +438,7 @@ async def view_page(request: Request, name: str):
         page_metadata=frontmatter,
         recent_pages=recent_pages,
         all_pages=all_pages,
+        page_contents=page_contents,
     )
 
     return templates.TemplateResponse(

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -1,5 +1,6 @@
 """MeshWiki FastAPI application."""
 
+import asyncio
 import json
 import re
 import time
@@ -424,11 +425,12 @@ async def view_page(request: Request, name: str):
 
     # Fetch all page contents for <<Include>> macro.
     page_contents: dict[str, str] = {}
-    all_page_names = await storage.list_pages()
-    for page_name in all_page_names:
-        raw = await storage.get_raw_content(page_name)
-        if raw is not None:
-            page_contents[page_name] = raw
+    if "<<Include(" in page.content:
+        all_page_names = await storage.list_pages()
+        raws = await asyncio.gather(
+            *(storage.get_raw_content(n) for n in all_page_names)
+        )
+        page_contents = {n: r for n, r in zip(all_page_names, raws) if r is not None}
 
     # Parse content with wiki links, TOC, and page context for macros.
     html_content, toc_html = parse_wiki_content_with_toc(

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -427,10 +427,10 @@ async def view_page(request: Request, name: str):
     page_contents: dict[str, str] = {}
     if "<<Include(" in page.content:
         all_page_names = await storage.list_pages()
-        raws = await asyncio.gather(
-            *(storage.get_raw_content(n) for n in all_page_names)
-        )
-        page_contents = {n: r for n, r in zip(all_page_names, raws) if r is not None}
+        pages = await asyncio.gather(*(storage.get_page(n) for n in all_page_names))
+        page_contents = {
+            n: p.content for n, p in zip(all_page_names, pages) if p is not None
+        }
 
     # Parse content with wiki links, TOC, and page context for macros.
     html_content, toc_html = parse_wiki_content_with_toc(

--- a/src/tests/test_include_macro.py
+++ b/src/tests/test_include_macro.py
@@ -1,0 +1,322 @@
+"""Unit tests for the <<Include(...)>> macro."""
+
+from meshwiki.core.parser import parse_wiki_content
+
+
+def render(
+    text: str, page_contents: dict[str, str] | None = None, current_page: str = ""
+) -> str:
+    """Render text through the parser with page contents."""
+    return parse_wiki_content(
+        text, page_contents=page_contents or {}, page_name=current_page
+    )
+
+
+class TestIncludeBasic:
+    """Basic include rendering tests."""
+
+    def test_basic_include(self):
+        """<<Include(PageName)>> embeds the rendered content of PageName."""
+        page_contents = {
+            "TargetPage": "# Hello World\n\nThis is the target page content.",
+        }
+        html = render(
+            "Before\n\n<<Include(TargetPage)>>\n\nAfter", page_contents=page_contents
+        )
+        assert "include-content" in html
+        assert "Hello World" in html
+        assert "This is the target page content" in html
+
+    def test_missing_page_shows_placeholder(self):
+        """<<Include(MissingPage)>> when page doesn't exist shows placeholder."""
+        html = render("<<Include(MissingPage)>>", page_contents={})
+        assert "include-missing" in html
+        assert "[[MissingPage]]" in html
+
+    def test_include_multiple_pages(self):
+        """Multiple <<Include(...)>> macros work in the same document."""
+        page_contents = {
+            "PageA": "# Content A",
+            "PageB": "# Content B",
+        }
+        html = render(
+            "<<Include(PageA)>>\n\n<<Include(PageB)>>", page_contents=page_contents
+        )
+        assert html.count("include-content") == 2
+        assert "Content A" in html
+        assert "Content B" in html
+
+
+class TestIncludeWithHeading:
+    """Tests for <<Include(PageName, "Heading", level)>> syntax."""
+
+    def test_heading_with_level(self):
+        """<<Include(PageName, "Title", 2)>> prepends an H2 heading."""
+        page_contents = {
+            "Docs/Guide": "This is the guide content.",
+        }
+        html = render(
+            '<<Include(Docs/Guide, "Custom Title", 2)>>',
+            page_contents=page_contents,
+        )
+        assert "<h2>Custom Title</h2>" in html
+        assert "This is the guide content" in html
+
+    def test_heading_level_1_to_6(self):
+        """Heading levels 1-6 are respected."""
+        page_contents = {"Page": "Content"}
+        for level in range(1, 7):
+            html = render(
+                f'<<Include(Page, "Title", {level})>>',
+                page_contents=page_contents,
+            )
+            assert f"<h{level}>Title</h{level}>" in html
+
+    def test_heading_defaults_to_page_name_when_level_only(self):
+        """<<Include(PageName, , 3)>> uses page name as heading text."""
+        page_contents = {"MyPage": "Content here."}
+        html = render("<<Include(MyPage, , 3)>>", page_contents=page_contents)
+        assert "<h3>MyPage</h3>" in html
+        assert "Content here" in html
+
+    def test_level_clamped_to_1_6(self):
+        """Levels outside 1-6 are clamped."""
+        page_contents = {"Page": "Content"}
+        html = render('<<Include(Page, "Title", 10)>>', page_contents=page_contents)
+        assert "<h6>Title</h6>" in html
+
+
+class TestIncludeSnippets:
+    """Tests for from/to snippet extraction."""
+
+    def test_from_marker_only(self):
+        """<<Include(PageName, , , from="StartText")>> extracts from marker to end."""
+        page_contents = {
+            "SnippetPage": """# Header
+
+StartText
+This should be included.
+More content here.
+""",
+        }
+        html = render(
+            '<<Include(SnippetPage, , , from="StartText")>>',
+            page_contents=page_contents,
+        )
+        assert "This should be included" in html
+        assert "StartText" not in html
+
+    def test_to_marker_only(self):
+        """<<Include(PageName, , , to="EndText")>> extracts from start to marker."""
+        page_contents = {
+            "SnippetPage": """# Header
+
+This should be included.
+More content here.
+EndText
+""",
+        }
+        html = render(
+            '<<Include(SnippetPage, , , to="EndText")>>',
+            page_contents=page_contents,
+        )
+        assert "This should be included" in html
+        assert "EndText" not in html
+
+    def test_from_and_to_markers(self):
+        """<<Include(PageName, , , from="A", to="B")>> extracts between markers."""
+        page_contents = {
+            "SnippetPage": """# Header
+
+Before A section.
+A
+Middle content here.
+B
+After B section.
+""",
+        }
+        html = render(
+            '<<Include(SnippetPage, , , from="A", to="B")>>',
+            page_contents=page_contents,
+        )
+        assert "Middle content here" in html
+        assert "Before A section" not in html
+        assert "After B section" not in html
+
+    def test_snippet_with_heading(self):
+        """Snippet extraction combined with heading works."""
+        page_contents = {
+            "Guide": """# Guide Title
+
+StartHere
+Extracted content.
+EndHere
+""",
+        }
+        html = render(
+            '<<Include(Guide, "My Heading", 2, from="StartHere", to="EndHere")>>',
+            page_contents=page_contents,
+        )
+        assert "<h2>My Heading</h2>" in html
+        assert "Extracted content" in html
+
+
+class TestIncludePattern:
+    """Tests for pattern includes like <<Include(Docs/*)>>."""
+
+    def test_pattern_include_all_matching(self):
+        """<<Include(Docs/*)>> includes all pages under Docs/."""
+        page_contents = {
+            "Docs/Intro": "# Introduction\n\nWelcome to the docs.",
+            "Docs/Setup": "# Setup\n\nGetting started.",
+            "Docs/Advanced": "# Advanced\n\nDeep dive.",
+            "Blog/Post": "# Blog Post\n\nNot in docs.",
+        }
+        html = render("<<Include(Docs/*)>>", page_contents=page_contents)
+        assert "Introduction" in html
+        assert "Setup" in html
+        assert "Advanced" in html
+        assert "Blog Post" not in html
+
+    def test_pattern_include_sort_ascending(self):
+        """<<Include(Docs/*, , , sort=ascending)>> sorts alphabetically ascending."""
+        page_contents = {
+            "Docs/Zebra": "# Zebra",
+            "Docs/Apple": "# Apple",
+            "Docs/Banana": "# Banana",
+        }
+        html = render(
+            "<<Include(Docs/*, , , sort=ascending)>>", page_contents=page_contents
+        )
+        apple_pos = html.find("Apple")
+        banana_pos = html.find("Banana")
+        zebra_pos = html.find("Zebra")
+        assert apple_pos < banana_pos < zebra_pos
+
+    def test_pattern_include_sort_descending(self):
+        """<<Include(Docs/*, , , sort=descending)>> sorts alphabetically descending."""
+        page_contents = {
+            "Docs/Zebra": "# Zebra",
+            "Docs/Apple": "# Apple",
+            "Docs/Banana": "# Banana",
+        }
+        html = render(
+            "<<Include(Docs/*, , , sort=descending)>>", page_contents=page_contents
+        )
+        apple_pos = html.find("Apple")
+        banana_pos = html.find("Banana")
+        zebra_pos = html.find("Zebra")
+        assert zebra_pos < banana_pos < apple_pos
+
+    def test_pattern_no_matches(self):
+        """<<Include(Foo/*)>> when no pages match shows missing placeholder."""
+        page_contents = {
+            "Bar/Page": "# Bar Page",
+        }
+        html = render("<<Include(Foo/*)>>", page_contents=page_contents)
+        assert "include-missing" in html
+
+
+class TestIncludeCircular:
+    """Tests for circular include detection."""
+
+    def test_circular_include_skipped(self):
+        """Page including itself shows circular skip message."""
+        page_contents = {
+            "SelfPage": "# Self Content\n\n<<Include(SelfPage)>>",
+        }
+        html = render(
+            "<<Include(SelfPage)>>",
+            page_contents=page_contents,
+            current_page="SelfPage",
+        )
+        assert "include-circular" in html
+        assert "circular include skipped" in html
+
+    def test_circular_not_detected_when_different_page(self):
+        """<<Include(OtherPage)>> from PageName does NOT trigger circular."""
+        page_contents = {
+            "PageA": "# Content A",
+            "PageB": "# Content B\n\n<<Include(PageA)>>",
+        }
+        html = render(
+            "<<Include(PageB)>>", page_contents=page_contents, current_page="PageB"
+        )
+        assert "circular" not in html
+        assert "Content A" in html
+
+
+class TestIncludeFrontmatter:
+    """Tests for frontmatter stripping."""
+
+    def test_frontmatter_stripped(self):
+        """Frontmatter is stripped from included page content."""
+        page_contents = {
+            "WithFrontmatter": """---
+title: Test Page
+tags: [test, sample]
+---
+
+# Actual Content
+
+This is the real content.
+""",
+        }
+        html = render("<<Include(WithFrontmatter)>>", page_contents=page_contents)
+        assert "Actual Content" in html
+        assert "This is the real content" in html
+        assert "title: Test Page" not in html
+        assert "tags:" not in html
+
+
+class TestIncludeCodeBlockEscaping:
+    """Tests for code block escaping."""
+
+    def test_not_expanded_in_fenced_code_block(self):
+        """<<Include(...)>> inside ``` code blocks is NOT expanded."""
+        page_contents = {
+            "TargetPage": "# Should Not Appear",
+        }
+        content = "```\n<<Include(TargetPage)>>\n```"
+        html = render(content, page_contents=page_contents)
+        assert "include-content" not in html
+        assert "&lt;&lt;Include(TargetPage)&gt;&gt;" in html
+
+    def test_not_expanded_in_tilde_code_block(self):
+        """<<Include(...)>> inside ~~~ code blocks is NOT expanded."""
+        page_contents = {
+            "TargetPage": "# Should Not Appear",
+        }
+        content = "~~~\n<<Include(TargetPage)>>\n~~~"
+        html = render(content, page_contents=page_contents)
+        assert "include-content" not in html
+
+
+class TestIncludeEdgeCases:
+    """Edge case tests."""
+
+    def test_empty_page_content(self):
+        """<<Include(EmptyPage)>> with empty page renders without error."""
+        page_contents = {
+            "EmptyPage": "",
+        }
+        html = render("<<Include(EmptyPage)>>", page_contents=page_contents)
+        assert "include-content" in html
+
+    def test_page_name_with_spaces(self):
+        """<<Include(Page Name)>> with spaces in name works."""
+        page_contents = {
+            "Page Name": "# Content",
+        }
+        html = render("<<Include(Page Name)>>", page_contents=page_contents)
+        assert "include-content" in html
+        assert "Content" in html
+
+    def test_page_name_with_slashes(self):
+        """<<Include(Docs/SubPage)>> with subpage path works."""
+        page_contents = {
+            "Docs/SubPage": "# SubPage Content",
+        }
+        html = render("<<Include(Docs/SubPage)>>", page_contents=page_contents)
+        assert "include-content" in html
+        assert "SubPage Content" in html

--- a/src/tests/test_include_macro.py
+++ b/src/tests/test_include_macro.py
@@ -79,6 +79,13 @@ class TestIncludeWithHeading:
         assert "<h3>MyPage</h3>" in html
         assert "Content here" in html
 
+    def test_heading_defaults_to_level_2_when_text_only(self):
+        """<<Include(PageName, "Title")>> uses level 2 by default."""
+        page_contents = {"MyPage": "Content here."}
+        html = render('<<Include(MyPage, "Title")>>', page_contents=page_contents)
+        assert "<h2>Title</h2>" in html
+        assert "Content here" in html
+
     def test_level_clamped_to_1_6(self):
         """Levels outside 1-6 are clamped."""
         page_contents = {"Page": "Content"}

--- a/src/tests/test_include_macro.py
+++ b/src/tests/test_include_macro.py
@@ -252,6 +252,15 @@ class TestIncludeCircular:
         assert "circular" not in html
         assert "Content A" in html
 
+    def test_circular_pattern_include_skipped(self):
+        """Circular detection works inside pattern includes."""
+        page_contents = {
+            "Docs/Page1": "# Doc Page 1",
+            "Docs/Page2": "# Doc Page 2\n\n<<Include(Docs/Page1)>>\n\n<<Include(Docs/Page2)>>",
+        }
+        html = render("<<Include(Docs/*)>>", page_contents=page_contents)
+        assert html.count("include-circular") == 1
+
 
 class TestIncludeFrontmatter:
     """Tests for frontmatter stripping."""


### PR DESCRIPTION
## Summary
Implements the `<<Include(PageName)>>` macro for embedding wiki page content into other pages, following MoinMoin/Graphingwiki conventions.

### Features
- **Basic include**: `<<Include(PageName)>>` embeds full page content
- **With heading**: `<<Include(PageName, \"Title\", 2)>>` prepends an H2 heading
- **Snippet extraction**: `<<Include(PageName, , , from=\"Start\", to=\"End\")>>` extracts content between markers
- **Pattern includes**: `<<Include(Docs/*, , , sort=descending)>>` includes all pages matching prefix

### Implementation Details
- Uses Pattern B (async data via constructor parameter) to avoid `asyncio.run()` in preprocessors
- Pre-fetches page contents in route handler and passes as `page_contents` dict
- Circular detection via `include_chain` tracking (prevents infinite recursion)
- Frontmatter stripped from included content
- Macros inside fenced code blocks are not expanded

### Testing
- 23 unit tests covering all acceptance criteria
- All 437 tests pass (32 skipped)

### Files Changed
- `src/meshwiki/core/parser.py` — IncludePreprocessor, IncludeExtension, updated functions
- `src/meshwiki/main.py` — pass page_contents to parser in view_page
- `src/tests/test_include_macro.py` — new test file