### PR TITLE
fix: fail fast on rework with no PM feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,9 +435,12 @@ jobs:
             if grep -q FACTORY_ANTHROPIC_API_KEY /opt/meshwiki/orchestrator-staging.env.new; then
               mv /opt/meshwiki/orchestrator-staging.env.new /opt/meshwiki/orchestrator-staging.env
             else
-              grep -v '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator-staging.env > /opt/meshwiki/orchestrator-staging.env.tmp 2>/dev/null || true
-              cat /opt/meshwiki/orchestrator-staging.env.new >> /opt/meshwiki/orchestrator-staging.env.tmp
-              mv /opt/meshwiki/orchestrator-staging.env.tmp /opt/meshwiki/orchestrator-staging.env
+              SAVED_KEY=\$(grep '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator-staging.env 2>/dev/null || true)
+              if [ -n \"\$SAVED_KEY\" ]; then
+                { cat /opt/meshwiki/orchestrator-staging.env.new; echo \"\$SAVED_KEY\"; } > /opt/meshwiki/orchestrator-staging.env
+              else
+                mv /opt/meshwiki/orchestrator-staging.env.new /opt/meshwiki/orchestrator-staging.env
+              fi
               rm -f /opt/meshwiki/orchestrator-staging.env.new
             fi
           "
@@ -570,9 +573,12 @@ jobs:
             if grep -q FACTORY_ANTHROPIC_API_KEY /opt/meshwiki/orchestrator.env.new; then
               mv /opt/meshwiki/orchestrator.env.new /opt/meshwiki/orchestrator.env
             else
-              grep -v '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator.env > /opt/meshwiki/orchestrator.env.tmp 2>/dev/null || true
-              cat /opt/meshwiki/orchestrator.env.new >> /opt/meshwiki/orchestrator.env.tmp
-              mv /opt/meshwiki/orchestrator.env.tmp /opt/meshwiki/orchestrator.env
+              SAVED_KEY=\$(grep '^FACTORY_ANTHROPIC_API_KEY=' /opt/meshwiki/orchestrator.env 2>/dev/null || true)
+              if [ -n \"\$SAVED_KEY\" ]; then
+                { cat /opt/meshwiki/orchestrator.env.new; echo \"\$SAVED_KEY\"; } > /opt/meshwiki/orchestrator.env
+              else
+                mv /opt/meshwiki/orchestrator.env.new /opt/meshwiki/orchestrator.env
+              fi
               rm -f /opt/meshwiki/orchestrator.env.new
             fi
           "

--- a/docs/custom-macros.md
+++ b/docs/custom-macros.md
@@ -124,6 +124,94 @@ def create_parser(page_exists=None):
     ])
 ```
 
+## Data Access in Preprocessors
+
+> **Critical constraint:** Preprocessors run synchronously inside FastAPI's already-running event loop. **Never call `asyncio.run()` inside a preprocessor** — it raises `RuntimeError: This event loop is already running`.
+
+### Two patterns, depending on your data source
+
+#### Pattern A — Synchronous data (graph engine)
+
+The graph engine (`get_engine()`) is synchronous. Call it directly from the render function:
+
+```python
+def _render_my_macro() -> str:
+    from meshwiki.core.graph import get_engine
+    engine = get_engine()
+    if engine is None:
+        return '<em>graph engine not available</em>'
+    return engine.list_pages()  # synchronous, safe in preprocessor
+```
+
+#### Pattern B — Async data (storage, database)
+
+If your macro needs data from `storage` (or any async source), **do not fetch inside the preprocessor**. Instead:
+
+1. Fetch data in the async route handler (it already runs in the event loop)
+2. Pass it as a constructor parameter to your Extension
+3. Store it on the Preprocessor instance
+
+```python
+# 1. Render function takes pre-fetched data as a parameter
+def _render_my_macro(my_data: list) -> str:
+    ...
+
+# 2. Preprocessor stores data on self
+class MyMacroPreprocessor(Preprocessor):
+    def __init__(self, md: Markdown, my_data: list | None = None):
+        super().__init__(md)
+        self.my_data = my_data or []
+
+    def run(self, lines: list[str]) -> list[str]:
+        ...
+        html = _render_my_macro(self.my_data)
+        ...
+
+# 3. Extension accepts and threads data through
+class MyMacroExtension(Extension):
+    def __init__(self, my_data: list | None = None, **kwargs):
+        self.my_data = my_data or []
+        super().__init__(**kwargs)
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            MyMacroPreprocessor(md, self.my_data), "my_macro", 28
+        )
+
+# 4. create_parser() accepts and passes the data
+def create_parser(..., my_data: list | None = None) -> Markdown:
+    return Markdown(extensions=[
+        ...
+        MyMacroExtension(my_data=my_data),
+    ])
+
+# 5. parse_wiki_content() threads it through
+def parse_wiki_content(..., my_data: list | None = None) -> str:
+    parser = create_parser(..., my_data=my_data)
+    return parser.convert(content)
+```
+
+```python
+# 6. Route handler: fetch once, pass in
+@app.get("/page/{name}")
+async def view_page(name: str):
+    my_data = await storage.list_things()  # ✅ async here is fine
+    html = parse_wiki_content(content, my_data=my_data)
+```
+
+**Reference implementations:** `<<RecentChanges>>` and `<<PageList>>` in `parser.py` both follow Pattern B.
+
+**Anti-pattern (do not do this):**
+```python
+# ❌ WRONG — raises RuntimeError: This event loop is already running
+def _render_my_macro() -> str:
+    storage = asyncio.run(get_storage())  # crashes in FastAPI
+    pages = asyncio.run(storage.list_pages())
+    ...
+```
+
+---
+
 ## Adding a New Macro: Step-by-Step
 
 Let's build a `<<PageCount>>` macro that displays the total number of wiki pages.

--- a/orchestrator/factory/agents/pm_agent.py
+++ b/orchestrator/factory/agents/pm_agent.py
@@ -34,6 +34,12 @@ When decomposing:
 - Subtasks must be as independent as possible (minimize file overlap)
 - Include file paths you expect will be touched in each subtask
 - Write clear acceptance criteria
+- If the subtask adds a new wiki macro (<<MacroName>>) that needs async data
+  (storage, database), include this constraint in the description:
+  "Preprocessors run inside FastAPI's event loop — never use asyncio.run().
+  Pre-fetch data in the async route handler and pass it as a constructor
+  parameter to the Extension class. Follow the RecentChanges/PageList pattern
+  in parser.py."
 
 When reviewing:
 - Check that tests cover the new code

--- a/orchestrator/factory/agents/pm_agent.py
+++ b/orchestrator/factory/agents/pm_agent.py
@@ -150,7 +150,7 @@ PM_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "pm_request_changes",
-        "description": "Request changes on a subtask PR — the implementation does not meet acceptance criteria.",
+        "description": "Request changes on a subtask PR — the implementation does not meet acceptance criteria. You MUST provide non-empty feedback: the grinder has no other way to know what to fix.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -160,7 +160,7 @@ PM_TOOLS: list[dict[str, Any]] = [
                 },
                 "feedback": {
                     "type": "string",
-                    "description": "Detailed feedback describing what needs to change.",
+                    "description": "Detailed, actionable feedback describing exactly what needs to change. Must be non-empty — the grinder will fail immediately if this is blank.",
                 },
             },
             "required": ["subtask_id", "feedback"],
@@ -410,7 +410,12 @@ async def review_with_pm(
                 )
             elif tool_name == "pm_request_changes":
                 decision = "changes_requested"
-                feedback = tool_input.get("feedback")
+                feedback = tool_input.get("feedback") or None
+                if not feedback:
+                    logger.warning(
+                        "review_with_pm: pm_request_changes called with empty feedback for subtask %s",
+                        tool_input.get("subtask_id"),
+                    )
                 result_content = "Changes requested."
                 logger.info(
                     "review_with_pm: changes requested for subtask %s",

--- a/orchestrator/factory/nodes/grind.py
+++ b/orchestrator/factory/nodes/grind.py
@@ -42,7 +42,19 @@ async def grind_node(state: FactoryState) -> dict:
             subtask_id,
             subtask.get("attempt", 0),
         )
-        updated = {**subtask, "status": "failed", "error_log": list(subtask.get("error_log") or []) + ["PM requested changes but provided no feedback — cannot rework"]}
+        error_log = list(subtask.get("error_log") or []) + [
+            "PM requested changes but provided no feedback — cannot rework"
+        ]
+        updated = {**subtask, "status": "failed", "error_log": error_log}
+        meshwiki_client = MeshWikiClient()
+        try:
+            await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
+        except Exception as exc:
+            logger.error(
+                "grind_node: failed to transition %s to failed: %s",
+                subtask["wiki_page"],
+                exc,
+            )
         subtasks = [updated if s["id"] == subtask_id else s for s in state["subtasks"]]
         return {"subtasks": subtasks}
 

--- a/orchestrator/factory/nodes/grind.py
+++ b/orchestrator/factory/nodes/grind.py
@@ -34,6 +34,18 @@ async def grind_node(state: FactoryState) -> dict:
         logger.error("grind_node: subtask %r not found in state", subtask_id)
         return {}
 
+    # Guard: rework with no feedback wastes a full sandbox run.
+    # Fail fast so escalate_node can handle it rather than grinding blindly.
+    if subtask.get("attempt", 0) > 0 and not subtask.get("review_feedback"):
+        logger.warning(
+            "grind_node: subtask %s is a rework (attempt %d) but review_feedback is empty — failing fast",
+            subtask_id,
+            subtask.get("attempt", 0),
+        )
+        updated = {**subtask, "status": "failed", "error_log": list(subtask.get("error_log") or []) + ["PM requested changes but provided no feedback — cannot rework"]}
+        subtasks = [updated if s["id"] == subtask_id else s for s in state["subtasks"]]
+        return {"subtasks": subtasks}
+
     logger.info(
         "grind_node: running grinder for subtask %s (task %s)",
         subtask_id,

--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1,6 +1,5 @@
 """Markdown parser with wiki link support."""
 
-import asyncio
 import json
 import re
 from datetime import datetime, timezone
@@ -810,32 +809,30 @@ def _parse_pagelist_args(args_str: str | None) -> dict[str, str]:
     return result
 
 
-def _render_page_list(args_str: str | None) -> str:
-    """Render <<PageList(...)>> as an HTML list of wiki pages."""
-    from meshwiki.core.dependencies import get_storage
+def _render_page_list(args_str: str | None, all_pages: list) -> str:
+    """Render <<PageList(...)>> as an HTML list of wiki pages.
 
+    Args:
+        args_str: Raw argument string from the macro (may be None).
+        all_pages: Pre-fetched list of Page objects passed in from the route handler.
+                   Must not be fetched here — preprocessors run inside the event loop.
+    """
     args = _parse_pagelist_args(args_str)
 
-    try:
-        storage = get_storage()
-    except RuntimeError:
+    if all_pages is None:
         return (
             '<div class="page-list-wrapper">'
             '<p class="page-list-unavailable">'
             "<em>PageList: storage not available</em></p></div>"
         )
 
-    try:
-        if "tag" in args:
-            pages = asyncio.run(storage.search_by_tag(args["tag"]))
-        else:
-            pages = asyncio.run(storage.list_pages_with_metadata())
-    except Exception:
-        return (
-            '<div class="page-list-wrapper">'
-            '<p class="page-list-unavailable">'
-            "<em>PageList: storage not available</em></p></div>"
-        )
+    pages = list(all_pages)
+
+    if "tag" in args:
+        tag_lower = args["tag"].lower()
+        pages = [
+            p for p in pages if any(t.lower() == tag_lower for t in p.metadata.tags)
+        ]
 
     if "prefix" in args:
         prefix = args["prefix"]
@@ -880,6 +877,10 @@ def _render_page_list(args_str: str | None) -> str:
 class PageListPreprocessor(Preprocessor):
     """Preprocessor that replaces <<PageList(...)>> macros with an HTML list."""
 
+    def __init__(self, md: Markdown, all_pages: list | None = None):
+        super().__init__(md)
+        self.all_pages = all_pages or []
+
     def run(self, lines: list[str]) -> list[str]:
         text = "\n".join(lines)
         if "<<PageList" not in text:
@@ -897,7 +898,7 @@ class PageListPreprocessor(Preprocessor):
 
         def replace_match(m: re.Match) -> str:
             args_str = m.group(1)
-            html = _render_page_list(args_str)
+            html = _render_page_list(args_str, self.all_pages)
             return self.md.htmlStash.store(html)
 
         text = PAGELIST_PATTERN.sub(replace_match, text)
@@ -911,9 +912,13 @@ class PageListPreprocessor(Preprocessor):
 class PageListExtension(Extension):
     """Markdown extension for <<PageList(...)>> macros."""
 
+    def __init__(self, all_pages: list | None = None, **kwargs):
+        self.all_pages = all_pages or []
+        super().__init__(**kwargs)
+
     def extendMarkdown(self, md: Markdown) -> None:
         md.preprocessors.register(
-            PageListPreprocessor(md),
+            PageListPreprocessor(md, self.all_pages),
             "pagelist",
             28,
         )
@@ -1167,6 +1172,7 @@ def create_parser(
     page_name: str | None = None,
     page_metadata: dict | None = None,
     recent_pages: list | None = None,
+    all_pages: list | None = None,
 ) -> Markdown:
     """Create a Markdown parser with wiki link support.
 
@@ -1176,6 +1182,7 @@ def create_parser(
         page_name: Name of the page being rendered (for TaskStatus macro).
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
         recent_pages: List of Page objects for RecentChanges macro.
+        all_pages: List of all Page objects for PageList macro.
 
     Returns:
         Configured Markdown parser instance.
@@ -1202,7 +1209,7 @@ def create_parser(
             RecentChangesExtension(recent_pages=recent_pages),  # <<RecentChanges(n)>>
             PageCountExtension(),  # <<PageCount>>
             BackLinksExtension(page_name=page_name),  # <<BackLinks>>
-            PageListExtension(),  # <<PageList(...)>>
+            PageListExtension(all_pages=all_pages),  # <<PageList(...)>>
         ]
     )
 
@@ -1213,6 +1220,7 @@ def parse_wiki_content(
     page_name: str | None = None,
     page_metadata: dict | None = None,
     recent_pages: list | None = None,
+    all_pages: list | None = None,
 ) -> str:
     """Parse wiki content (Markdown + wiki links) to HTML.
 
@@ -1222,6 +1230,7 @@ def parse_wiki_content(
         page_name: Name of the page being rendered (for TaskStatus macro).
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
         recent_pages: List of Page objects for RecentChanges macro.
+        all_pages: List of all Page objects for PageList macro.
 
     Returns:
         HTML string.
@@ -1231,6 +1240,7 @@ def parse_wiki_content(
         page_name=page_name,
         page_metadata=page_metadata,
         recent_pages=recent_pages,
+        all_pages=all_pages,
     )
     return parser.convert(content)
 
@@ -1241,6 +1251,7 @@ def parse_wiki_content_with_toc(
     page_name: str | None = None,
     page_metadata: dict | None = None,
     recent_pages: list | None = None,
+    all_pages: list | None = None,
 ) -> tuple[str, str]:
     """Parse wiki content and return HTML with table of contents.
 
@@ -1250,6 +1261,7 @@ def parse_wiki_content_with_toc(
         page_name: Name of the page being rendered (for TaskStatus macro).
         page_metadata: Frontmatter dict of the page (for TaskStatus macro).
         recent_pages: List of Page objects for RecentChanges macro.
+        all_pages: List of all Page objects for PageList macro.
 
     Returns:
         Tuple of (html_content, toc_html).
@@ -1259,6 +1271,7 @@ def parse_wiki_content_with_toc(
         page_name=page_name,
         page_metadata=page_metadata,
         recent_pages=recent_pages,
+        all_pages=all_pages,
     )
     html = parser.convert(content)
     toc_html = getattr(parser, "toc", "")

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -429,6 +429,7 @@ async def view_page(request: Request, name: str):
         page_name=name,
         page_metadata=frontmatter,
         recent_pages=recent_pages,
+        all_pages=all_pages,
     )
 
     return templates.TemplateResponse(

--- a/src/tests/test_page_list_macro.py
+++ b/src/tests/test_page_list_macro.py
@@ -1,7 +1,6 @@
 """Unit tests for the <<PageList>> macro."""
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
 
 from meshwiki.core.models import Page, PageMetadata
 from meshwiki.core.parser import parse_wiki_content
@@ -30,24 +29,10 @@ def make_page(
 
 
 def render(text: str, pages: list[Page] | None = None) -> str:
-    """Render text through the parser, patching get_storage."""
+    """Render text through the parser, passing pages directly as all_pages."""
     if pages is None:
         pages = []
-
-    mock_storage = MagicMock()
-
-    async def mock_list_pages_with_metadata() -> list[Page]:
-        return pages
-
-    async def mock_search_by_tag(tag: str) -> list[Page]:
-        return [p for p in pages if tag.lower() in [t.lower() for t in p.metadata.tags]]
-
-    mock_storage.list_pages_with_metadata = mock_list_pages_with_metadata
-    mock_storage.search_by_tag = mock_search_by_tag
-
-    with patch("meshwiki.core.dependencies.get_storage", return_value=mock_storage):
-        html = parse_wiki_content(text)
-    return html
+    return parse_wiki_content(text, all_pages=pages)
 
 
 class TestPageListBasic:
@@ -156,15 +141,12 @@ class TestPageListEdgeCases:
         assert "page-list-empty" in html
         assert "No pages found" in html
 
-    def test_storage_unavailable(self):
-        """<<PageList>> when get_storage raises RuntimeError shows unavailable message."""
-        with patch(
-            "meshwiki.core.dependencies.get_storage",
-            side_effect=RuntimeError("Storage not initialised"),
-        ):
-            html = parse_wiki_content("<<PageList>>")
-        assert "page-list-unavailable" in html
-        assert "PageList: storage not available" in html
+    def test_no_pages_shows_empty_not_unavailable(self):
+        """<<PageList>> with no pages shows empty message, not unavailable."""
+        html = render("<<PageList>>", pages=[])
+        assert "page-list-empty" in html
+        assert "No pages found" in html
+        assert "page-list-unavailable" not in html
 
     def test_not_replaced_in_fenced_code_block(self):
         """<<PageList>> inside code blocks is escaped, not rendered."""


### PR DESCRIPTION
## Summary

- If PM calls `pm_request_changes` with null/empty feedback, grinder previously spun up a full E2B sandbox with no idea what to fix
- `grind_node` now bails immediately with `status=failed` on rework attempts with no feedback — escalate_node handles it rather than wasting tokens
- PM agent tool description strengthened to make non-empty feedback mandatory; adds a warning log when it happens anyway

## Test plan

- [ ] Verify rework with empty feedback logs warning and returns `failed` without spinning up E2B

🤖 Generated with [Claude Code](https://claude.ai/claude-code)