### PR TITLE
[Factory] NewPage Macro — create page from template

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1276,6 +1276,87 @@ class IncludeExtension(Extension):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# NewPage macro
+# ─────────────────────────────────────────────────────────────────────────────
+
+NEWPAGE_PATTERN = re.compile(
+    r"<<NewPage[(]\s*([^,)]+?)\s*(?:,\s*\"([^\"]*)\")?\s*(?:,\s*([^,)]+?))?[)]>>",
+    re.DOTALL,
+)
+
+
+def _render_newpage_macro(
+    template_name: str, button_label: str, parent_page: str | None
+) -> str:
+    """Render the <<NewPage(...)>> macro as an inline form."""
+    if not button_label:
+        button_label = "New page"
+    escaped_template = html_escape(template_name)
+    escaped_label = html_escape(button_label)
+    escaped_parent = html_escape(parent_page or "")
+
+    if parent_page:
+        onclick = (
+            f"var input=this.previousElementSibling.value;"
+            f"if(input){{window.location.href='/page/{escaped_parent}/'+encodeURIComponent(input)+'/edit?template={escaped_template}'}}"
+        )
+    else:
+        onclick = (
+            f"var input=this.previousElementSibling.value;"
+            f"if(input){{window.location.href='/page/'+encodeURIComponent(input)+'/edit?template={escaped_template}'}}"
+        )
+
+    return (
+        f'<span class="new-page-macro">'
+        f'<input type="text" class="new-page-input" placeholder="Page name" />'
+        f'<button class="new-page-button" type="button" onclick="{onclick}">{escaped_label}</button>'
+        f"</span>"
+    )
+
+
+class NewPagePreprocessor(Preprocessor):
+    """Preprocessor that replaces <<NewPage(...)>> macros with an inline creation form."""
+
+    def run(self, lines: list[str]) -> list[str]:
+        text = "\n".join(lines)
+        if "<<NewPage(" not in text:
+            return lines
+
+        code_block_re = re.compile(r"(```.*?```|~~~.*?~~~)", re.DOTALL)
+        code_blocks: list[str] = []
+
+        def stash_code(m: re.Match) -> str:
+            placeholder = f"\x00NPEBLOCK{len(code_blocks)}\x00"
+            code_blocks.append(m.group(0))
+            return placeholder
+
+        text = code_block_re.sub(stash_code, text)
+
+        def replace_match(m: re.Match) -> str:
+            template_name = m.group(1).strip()
+            button_label = m.group(2) or ""
+            parent_page = m.group(3)
+            if parent_page:
+                parent_page = parent_page.strip()
+            html = _render_newpage_macro(template_name, button_label, parent_page)
+            return self.md.htmlStash.store(html)
+
+        text = NEWPAGE_PATTERN.sub(replace_match, text)
+
+        for i, block in enumerate(code_blocks):
+            text = text.replace(f"\x00NPEBLOCK{i}\x00", block)
+
+        return text.split("\n")
+
+
+class NewPageExtension(Extension):
+    """Markdown extension for <<NewPage(...)>> macros."""
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(NewPagePreprocessor(md), "newpage", 28)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # EpicStatus macro
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -1486,6 +1567,7 @@ def create_parser(
                 page_contents=page_contents or {},
                 include_chain=include_chain or [],
             ),  # <<Include(...)>>
+            NewPageExtension(),  # <<NewPage(...)>>
         ]
     )
 

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -45,6 +45,7 @@ from meshwiki.core.metrics import (
 )
 from meshwiki.core.models import Page
 from meshwiki.core.parser import (
+    FRONTMATTER_PATTERN,
     parse_wiki_content,
     parse_wiki_content_with_toc,
     word_count,
@@ -323,15 +324,21 @@ async def index(request: Request):
 
 
 @app.get("/page/{name:path}/edit", response_class=HTMLResponse)
-async def edit_page(request: Request, name: str):
+async def edit_page(request: Request, name: str, template: str = ""):
     """Edit page form."""
     _validate_page_name(name)
     page = await storage.get_page(name)
 
     if page is None:
-        # New page
         page = Page(name=name, content="", exists=False)
-        raw_content = ""
+        if template:
+            template_content = await storage.get_raw_content(template)
+            if template_content:
+                raw_content = FRONTMATTER_PATTERN.sub("", template_content)
+            else:
+                raw_content = ""
+        else:
+            raw_content = ""
     else:
         raw_content = await storage.get_raw_content(name) or ""
 

--- a/src/meshwiki/static/css/style.css
+++ b/src/meshwiki/static/css/style.css
@@ -1957,3 +1957,28 @@ article.page > .breadcrumb {
 .page-list-item:last-child { border-bottom: none; }
 .page-list-tags { display: flex; gap: 0.25rem; flex-wrap: wrap; }
 .page-list-empty, .page-list-unavailable { color: var(--color-text-muted, #888); font-style: italic; }
+
+/* NewPage macro */
+.new-page-macro { display: inline-flex; align-items: center; gap: 0.5rem; }
+.new-page-input {
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.9375rem;
+    border: 1px solid var(--color-border, #ccc);
+    background: var(--color-bg, #fff);
+    color: var(--color-text, #333);
+    min-width: 160px;
+}
+.new-page-button {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid var(--color-border, #ccc);
+    background: var(--color-bg, #fff);
+    color: var(--color-text, #333);
+    line-height: 1.4;
+}
+.new-page-button:hover { background: var(--color-bg-secondary, #f5f5f5); }

--- a/src/tests/test_editor.py
+++ b/src/tests/test_editor.py
@@ -170,3 +170,34 @@ class TestEditorTemplate:
         assert resp.status_code == 200
         assert "title: My Page" in resp.text
         assert "# Content" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_edit_with_template_prepopulates_content(self, client):
+        """GET /page/NewPage/edit?template=TemplateName pre-populates with template content."""
+        template_content = "---\ntitle: Task Template\ntags:\n  - task\n---\n\n# Task\n\nDescription here."
+        await meshwiki.main.storage.save_page("TaskTemplate", template_content)
+
+        resp = await client.get("/page/NewPage/edit?template=TaskTemplate")
+        assert resp.status_code == 200
+        assert "# Task" in resp.text
+        assert "Description here." in resp.text
+        assert "title: Task Template" not in resp.text
+
+    @pytest.mark.asyncio
+    async def test_edit_with_nonexistent_template_opens_empty(self, client):
+        """Template not found → editor opens empty (no error)."""
+        resp = await client.get("/page/NewPage/edit?template=NonexistentTemplate")
+        assert resp.status_code == 200
+        assert "<textarea" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_edit_with_existing_page_ignores_template(self, client):
+        """When page exists, template param is ignored."""
+        await meshwiki.main.storage.save_page("ExistingPage", "# Existing content")
+        template_content = "---\ntitle: Template\n---\n\n# Template content"
+        await meshwiki.main.storage.save_page("SomeTemplate", template_content)
+
+        resp = await client.get("/page/ExistingPage/edit?template=SomeTemplate")
+        assert resp.status_code == 200
+        assert "# Existing content" in resp.text
+        assert "# Template content" not in resp.text

--- a/src/tests/test_newpage_macro.py
+++ b/src/tests/test_newpage_macro.py
@@ -1,0 +1,148 @@
+"""Unit tests for the NewPage macro."""
+
+from meshwiki.core.parser import (
+    NEWPAGE_PATTERN,
+    NewPageExtension,
+    NewPagePreprocessor,
+    _render_newpage_macro,
+    parse_wiki_content,
+)
+
+
+class TestNewPagePattern:
+    def test_basic_pattern(self):
+        m = NEWPAGE_PATTERN.search("<<NewPage(MyTemplate)>>")
+        assert m is not None
+        assert m.group(1) == "MyTemplate"
+        assert m.group(2) is None
+        assert m.group(3) is None
+
+    def test_pattern_with_button_label(self):
+        m = NEWPAGE_PATTERN.search('<<NewPage(MyTemplate, "Create task")>>')
+        assert m is not None
+        assert m.group(1) == "MyTemplate"
+        assert m.group(2) == "Create task"
+        assert m.group(3) is None
+
+    def test_pattern_with_parent(self):
+        m = NEWPAGE_PATTERN.search('<<NewPage(MyTemplate, "Create", Projects)>>')
+        assert m is not None
+        assert m.group(1) == "MyTemplate"
+        assert m.group(2) == "Create"
+        assert m.group(3) == "Projects"
+
+    def test_pattern_default_button(self):
+        m = NEWPAGE_PATTERN.search("<<NewPage(MyTemplate)>>")
+        assert m is not None
+        assert m.group(2) is None
+
+    def test_pattern_whitespace(self):
+        m = NEWPAGE_PATTERN.search("<<NewPage(  MyTemplate  )>>")
+        assert m is not None
+        assert m.group(1).strip() == "MyTemplate"
+
+
+class TestRenderNewPageMacro:
+    def test_basic(self):
+        html = _render_newpage_macro("MyTemplate", "New page", None)
+        assert 'class="new-page-macro"' in html
+        assert 'class="new-page-input"' in html
+        assert 'class="new-page-button"' in html
+        assert "New page" in html
+        assert "MyTemplate" in html
+
+    def test_custom_button_label(self):
+        html = _render_newpage_macro("MyTemplate", "Create task", None)
+        assert "Create task" in html
+
+    def test_with_parent_page(self):
+        html = _render_newpage_macro("MyTemplate", "New page", "Projects")
+        assert "/page/Projects/" in html
+
+    def test_default_button_when_empty(self):
+        html = _render_newpage_macro("MyTemplate", "", None)
+        assert "New page" in html
+
+    def test_input_placeholder(self):
+        html = _render_newpage_macro("MyTemplate", "New page", None)
+        assert 'placeholder="Page name"' in html
+
+    def test_onclick_navigates_correctly(self):
+        html = _render_newpage_macro("MyTemplate", "New page", None)
+        assert "onclick=" in html
+        assert "/page/" in html
+        assert "template=MyTemplate" in html
+
+    def test_onclick_with_parent(self):
+        html = _render_newpage_macro("MyTemplate", "Create", "Projects")
+        assert "/page/Projects/" in html
+        assert "template=MyTemplate" in html
+
+    def test_html_escaping(self):
+        html = _render_newpage_macro('Template"X', 'Create "X"', None)
+        assert "&quot;" in html or "&#34;" in html
+
+
+class TestNewPagePreprocessor:
+    def test_skips_when_no_macro(self):
+        from markdown import Markdown
+
+        md = Markdown(extensions=[NewPageExtension()])
+        preprocessor = NewPagePreprocessor(md)
+        lines = ["Hello", "World"]
+        result = preprocessor.run(lines)
+        assert result == lines
+
+    def test_skips_fenced_code_blocks(self):
+        from markdown import Markdown
+
+        md = Markdown(extensions=[NewPageExtension()])
+        preprocessor = NewPagePreprocessor(md)
+        lines = ["```", "<<NewPage(MyTemplate)>>", "```"]
+        result = preprocessor.run(lines)
+        result_text = "\n".join(result)
+        assert "new-page-macro" not in result_text
+
+    def test_skips_tilde_fenced_code_blocks(self):
+        from markdown import Markdown
+
+        md = Markdown(extensions=[NewPageExtension()])
+        preprocessor = NewPagePreprocessor(md)
+        lines = ["~~~", "<<NewPage(MyTemplate)>>", "~~~"]
+        result = preprocessor.run(lines)
+        result_text = "\n".join(result)
+        assert "new-page-macro" not in result_text
+
+
+class TestNewPageInContent:
+    def test_basic_in_content(self):
+        html = parse_wiki_content("<<NewPage(MyTemplate)>>")
+        assert "new-page-macro" in html
+        assert "new-page-input" in html
+        assert "new-page-button" in html
+
+    def test_custom_label_in_content(self):
+        html = parse_wiki_content('<<NewPage(MyTemplate, "Create task")>>')
+        assert "Create task" in html
+
+    def test_with_parent_in_content(self):
+        html = parse_wiki_content('<<NewPage(MyTemplate, "Create", Projects)>>')
+        assert "/page/Projects/" in html
+
+    def test_multiple_macros(self):
+        html = parse_wiki_content(
+            '<<NewPage(Template1)>> and <<NewPage(Template2, "Label 2")>>'
+        )
+        assert html.count("new-page-macro") == 2
+
+    def test_macro_in_paragraph(self):
+        html = parse_wiki_content("Click <<NewPage(MyTemplate)>> to create.")
+        assert "new-page-macro" in html
+
+    def test_not_in_fenced_code(self):
+        html = parse_wiki_content("```\n<<NewPage(MyTemplate)>>\n```")
+        assert "new-page-macro" not in html
+
+    def test_not_in_tilde_fenced_code(self):
+        html = parse_wiki_content("~~~\n<<NewPage(MyTemplate)>>\n~~~")
+        assert "new-page-macro" not in html


### PR DESCRIPTION
## Summary
- Added `<<NewPage(TemplateName, \"Button Label\", ParentPage)>>` macro that renders an inline form for creating new wiki pages pre-populated with template content
- Modified `GET /page/{name}/edit` to accept optional `template` query parameter — if the page doesn't exist and template is provided, fetches template content (with frontmatter stripped) and pre-populates the editor
- Added minimal CSS styles for `.new-page-macro`, `.new-page-input`, `.new-page-button`

## Acceptance Criteria
- [x] `<<NewPage(MyTemplate)>>` renders a text input + "New page" button
- [x] `<<NewPage(MyTemplate, \"Create task\")>>` uses custom button label
- [x] `<<NewPage(MyTemplate, \"Create\", Projects)>>` prefixes input with `Projects/`
- [x] Clicking the button with a filled input navigates to correct edit URL
- [x] `GET /page/NewPage/edit?template=MyTemplate` pre-populates editor with template content (frontmatter stripped)
- [x] Template not found → editor opens empty (no error)
- [x] `<<NewPage(...)>>` inside fenced code blocks is not expanded
- [x] Unit tests in `src/tests/test_newpage_macro.py`
- [x] Integration tests for `?template=` edit route behaviour