### PR TITLE
[Factory] CalloutBlockPreprocessor and CSS

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1328,6 +1328,11 @@ class CalloutBlockPreprocessor(Preprocessor):
                 body_lines.append(lines[j])
                 j += 1
 
+            if j >= len(lines):
+                result.append(lines[i])
+                i += 1
+                continue
+
             escaped = html_escape("\n".join(body_lines))
             icon = CALLOUT_ICONS.get(callout_type, "")
             html = (

--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1284,6 +1284,75 @@ class IncludeExtension(Extension):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Callout Blocks
+# ─────────────────────────────────────────────────────────────────────────────
+
+CALLOUT_TYPES = ("info", "warning", "tip", "error", "note")
+
+CALLOUT_ICONS: dict[str, str] = {
+    "info": "ℹ️",
+    "warning": "⚠️",
+    "tip": "💡",
+    "error": "❌",
+    "note": "📝",
+}
+
+
+class CalloutBlockPreprocessor(Preprocessor):
+    """Preprocessor that converts fenced callout blocks to raw HTML."""
+
+    FENCE_RE = re.compile(r"^(?P<fence>`{3,}|~{3,})(?P<type>\w+)\s*$")
+
+    def run(self, lines: list[str]) -> list[str]:
+        result: list[str] = []
+        i = 0
+        while i < len(lines):
+            m = self.FENCE_RE.match(lines[i])
+            if not m:
+                result.append(lines[i])
+                i += 1
+                continue
+
+            fence_char = m.group("fence")
+            callout_type = m.group("type")
+            if callout_type not in CALLOUT_TYPES:
+                result.append(lines[i])
+                i += 1
+                continue
+
+            body_lines: list[str] = []
+            j = i + 1
+            while j < len(lines):
+                if lines[j].startswith(fence_char):
+                    break
+                body_lines.append(lines[j])
+                j += 1
+
+            escaped = html_escape("\n".join(body_lines))
+            icon = CALLOUT_ICONS.get(callout_type, "")
+            html = (
+                f'<div class="callout callout--{callout_type}">'
+                f'<span class="callout__icon">{icon}</span>'
+                f'<span class="callout__body">{escaped}</span></div>'
+            )
+            result.append(self.md.htmlStash.store(html))
+            i = j + 1
+
+        return result
+
+
+class CalloutExtension(Extension):
+    """Markdown extension for fenced callout blocks."""
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            CalloutBlockPreprocessor(md),
+            "callout",
+            27,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # NewPage macro
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -1566,6 +1635,7 @@ def create_parser(
                 include_chain=include_chain or [],
             ),  # <<Include(...)>>
             NewPageExtension(),  # <<NewPage(...)>>
+            CalloutExtension(),  # ```info / ```warning / ```tip / ```error / ```note
         ]
     )
 

--- a/src/meshwiki/static/css/style.css
+++ b/src/meshwiki/static/css/style.css
@@ -2025,3 +2025,91 @@ article.page > .breadcrumb {
     line-height: 1.4;
 }
 .new-page-button:hover { background: var(--color-bg-secondary, #f5f5f5); }
+
+/* === Callout Blocks === */
+.callout {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.9rem 1.1rem;
+  border-radius: 6px;
+  border-left: 4px solid;
+  margin: 1rem 0;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+.callout__icon { font-size: 1.2rem; flex-shrink: 0; }
+.callout__body { flex: 1; white-space: pre-wrap; }
+
+.callout--info {
+  --callout-info-bg: #e8f4fd;
+  --callout-info-border: #2196f3;
+  --callout-info-color: #0d47a1;
+  background: var(--callout-info-bg);
+  border-color: var(--callout-info-border);
+  color: var(--callout-info-color);
+}
+.callout--warning {
+  --callout-warning-bg: #fff8e1;
+  --callout-warning-border: #ffc107;
+  --callout-warning-color: #7b5e00;
+  background: var(--callout-warning-bg);
+  border-color: var(--callout-warning-border);
+  color: var(--callout-warning-color);
+}
+.callout--tip {
+  --callout-tip-bg: #e8f5e9;
+  --callout-tip-border: #4caf50;
+  --callout-tip-color: #1b5e20;
+  background: var(--callout-tip-bg);
+  border-color: var(--callout-tip-border);
+  color: var(--callout-tip-color);
+}
+.callout--error {
+  --callout-error-bg: #fdecea;
+  --callout-error-border: #f44336;
+  --callout-error-color: #b71c1c;
+  background: var(--callout-error-bg);
+  border-color: var(--callout-error-border);
+  color: var(--callout-error-color);
+}
+.callout--note {
+  --callout-note-bg: #f5f5f5;
+  --callout-note-border: #9e9e9e;
+  --callout-note-color: #424242;
+  background: var(--callout-note-bg);
+  border-color: var(--callout-note-border);
+  color: var(--callout-note-color);
+}
+
+[data-theme="dark"] .callout--info {
+  --callout-info-bg: #0d2137;
+  --callout-info-border: #42a5f5;
+  --callout-info-color: #90caf9;
+}
+[data-theme="dark"] .callout--warning {
+  --callout-warning-bg: #2a2000;
+  --callout-warning-border: #ffca28;
+  --callout-warning-color: #ffe082;
+}
+[data-theme="dark"] .callout--tip {
+  --callout-tip-bg: #0a2e0a;
+  --callout-tip-border: #66bb6a;
+  --callout-tip-color: #a5d6a7;
+}
+[data-theme="dark"] .callout--error {
+  --callout-error-bg: #2c0a0a;
+  --callout-error-border: #ef5350;
+  --callout-error-color: #ef9a9a;
+}
+[data-theme="dark"] .callout--note {
+  --callout-note-bg: #1e1e1e;
+  --callout-note-border: #bdbdbd;
+  --callout-note-color: #e0e0e0;
+}
+
+@media (max-width: 768px) {
+  .callout { font-size: 0.9rem; padding: 0.75rem 0.9rem; }
+}

--- a/src/tests/test_callout_macro.py
+++ b/src/tests/test_callout_macro.py
@@ -1,0 +1,197 @@
+"""Unit and integration tests for CalloutBlockPreprocessor."""
+
+import pytest
+
+from meshwiki.core.parser import parse_wiki_content
+
+
+class TestCalloutBlockPreprocessor:
+    """Test CalloutBlockPreprocessor with fenced code blocks."""
+
+    @pytest.mark.parametrize(
+        "callout_type,expected_class,expected_icon",
+        [
+            ("info", "callout--info", "ℹ️"),
+            ("warning", "callout--warning", "⚠️"),
+            ("tip", "callout--tip", "💡"),
+            ("error", "callout--error", "❌"),
+            ("note", "callout--note", "📝"),
+        ],
+    )
+    def test_callout_renders_correct_class_and_icon(
+        self, callout_type: str, expected_class: str, expected_icon: str
+    ):
+        content = f"```{callout_type}\nThis is a {callout_type} callout.\n```"
+        html = parse_wiki_content(content)
+        assert expected_class in html
+        assert expected_icon in html
+        assert "callout__icon" in html
+        assert "callout__body" in html
+
+    def test_callout_with_multiple_lines(self):
+        content = """```info
+Line one
+Line two
+Line three
+```"""
+        html = parse_wiki_content(content)
+        assert "callout--info" in html
+        assert "Line one" in html
+        assert "Line two" in html
+        assert "Line three" in html
+
+    def test_regular_code_block_not_affected(self):
+        content = "```python\nprint('hello')\n```"
+        html = parse_wiki_content(content)
+        assert "callout" not in html
+        assert "print" in html
+
+    def test_tilde_fence_callout(self):
+        content = """~~~tip
+This is a tip.
+~~~"""
+        html = parse_wiki_content(content)
+        assert "callout--tip" in html
+        assert "This is a tip." in html
+
+    def test_multiple_callouts_on_same_page(self):
+        content = """```info
+First info callout
+```
+Some text in between.
+```warning
+Warning callout here
+```
+More text.
+```tip
+A tip callout
+```"""
+        html = parse_wiki_content(content)
+        assert html.count("callout--info") == 1
+        assert html.count("callout--warning") == 1
+        assert html.count("callout--tip") == 1
+        assert "First info callout" in html
+        assert "Warning callout here" in html
+        assert "A tip callout" in html
+
+    def test_mixed_callouts_and_code_blocks(self):
+        content = """```python
+def hello():
+    print("world")
+```
+```info
+This is info
+```
+```tip
+And a tip
+```"""
+        html = parse_wiki_content(content)
+        assert "callout--info" in html
+        assert "callout--tip" in html
+        assert "def hello" in html
+
+    def test_callout_content_is_html_escaped(self):
+        content = """```error
+<script>alert('xss')</script>
+```"""
+        html = parse_wiki_content(content)
+        assert "callout--error" in html
+        assert "&lt;script&gt;" in html
+        assert "<script>" not in html
+
+    def test_unclosed_callout_passes_through(self):
+        content = """```info
+This callout has no closing fence
+just some text"""
+        html = parse_wiki_content(content)
+        assert "callout--info" not in html
+        assert "This callout has no closing fence" in html
+
+    def test_callout_type_not_case_sensitive(self):
+        content = "```INFO\nShould not match\n```"
+        html = parse_wiki_content(content)
+        assert "callout--INFO" not in html
+        assert "callout--info" not in html
+
+
+class TestCalloutCSS:
+    """Test that callout CSS is present in style.css."""
+
+    def test_callout_css_variables_present(self):
+        import meshwiki
+
+        css_path = meshwiki.__file__.rsplit("/", 1)[0] + "/static/css/style.css"
+        with open(css_path) as f:
+            css_content = f.read()
+
+        assert "--callout-info-bg" in css_content
+        assert "--callout-warning-bg" in css_content
+        assert "--callout-tip-bg" in css_content
+        assert "--callout-error-bg" in css_content
+        assert "--callout-note-bg" in css_content
+
+    def test_dark_mode_callout_variables_present(self):
+        import meshwiki
+
+        css_path = meshwiki.__file__.rsplit("/", 1)[0] + "/static/css/style.css"
+        with open(css_path) as f:
+            css_content = f.read()
+
+        assert '[data-theme="dark"] .callout--info' in css_content
+        assert '[data-theme="dark"] .callout--warning' in css_content
+        assert '[data-theme="dark"] .callout--tip' in css_content
+        assert '[data-theme="dark"] .callout--error' in css_content
+        assert '[data-theme="dark"] .callout--note' in css_content
+
+
+class TestCalloutViaHTTP:
+    """Integration tests for callouts via HTTP route."""
+
+    @pytest.mark.asyncio
+    async def test_callout_via_http_route(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        import meshwiki.main
+
+        meshwiki.main.storage.base_path = tmp_path
+        await meshwiki.main.storage.save_page(
+            "CalloutTest", "```info\nThis is an info callout.\n```"
+        )
+
+        transport = ASGITransport(app=meshwiki.main.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/page/CalloutTest")
+
+        assert resp.status_code == 200
+        assert "callout--info" in resp.text
+        assert "ℹ️" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_multiple_callouts_via_http(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        import meshwiki.main
+
+        meshwiki.main.storage.base_path = tmp_path
+        content = """```info
+First info
+```
+```warning
+A warning
+```
+```tip
+And a tip
+```"""
+        await meshwiki.main.storage.save_page("MultiCalloutTest", content)
+
+        transport = ASGITransport(app=meshwiki.main.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/page/MultiCalloutTest")
+
+        assert resp.status_code == 200
+        assert "callout--info" in resp.text
+        assert "callout--warning" in resp.text
+        assert "callout--tip" in resp.text
+        assert "ℹ️" in resp.text
+        assert "⚠️" in resp.text
+        assert "💡" in resp.text


### PR DESCRIPTION
## Summary

Implements the CalloutBlockPreprocessor Markdown extension and CSS for info/warning/tip/error/note callout blocks.

## Changes

- parser.py: Added CalloutBlockPreprocessor and CalloutExtension with priority 27 (higher than fenced_code at 25). Supports both triple-backtick and tilde fences.
- style.css: Added callout block styles with CSS custom properties for light/dark mode and mobile responsive adjustments.
- test_callout_macro.py: 17 tests covering all 5 callout types, regular code blocks, multiple callouts, HTML escaping, unclosed fence handling, CSS presence, and HTTP integration.

## Fixes Applied

1. Unclosed fence bug: If a callout fence opener is found but no closer exists before EOF, the opener is now passed through unchanged instead of silently dropping content.
2. html_escape import: Confirmed from html import escape as html_escape is present at line 6 of parser.py.
3. Test file: Added src/tests/test_callout_macro.py with all required test cases.