### PR TITLE
[Factory] CalloutBlockPreprocessor and CSS

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -258,6 +258,82 @@ class MetaTableExtension(Extension):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Callout Blocks
+# ─────────────────────────────────────────────────────────────────────────────
+
+CALLOUT_TYPES = {
+    "info": "\u2139\ufe0f",
+    "warning": "\u26a0\ufe0f",
+    "tip": "\ud83d\udca1",
+    "error": "\u274c",
+    "note": "\ud83d\udcdd",
+}
+
+
+class CalloutBlockPreprocessor(Preprocessor):
+    """Preprocessor that converts fenced code blocks with callout type tags into callout HTML."""
+
+    FENCE_OPEN_RE = re.compile(r"^(?P<fence>`{3,}|~{3,})(?P<lang>\w+)\s*$")
+
+    def run(self, lines: list[str]) -> list[str]:
+        result: list[str] = []
+        i = 0
+        while i < len(lines):
+            m = self.FENCE_OPEN_RE.match(lines[i])
+            if m is None:
+                result.append(lines[i])
+                i += 1
+                continue
+
+            fence_char = m.group("fence")[0]
+            lang = m.group("lang")
+            if lang not in CALLOUT_TYPES:
+                result.append(lines[i])
+                i += 1
+                continue
+
+            opener_len = len(m.group("fence"))
+            icon = CALLOUT_TYPES[lang]
+            body_lines: list[str] = []
+            j = i + 1
+            while j < len(lines):
+                if lines[j].startswith(fence_char) and (
+                    len(lines[j].strip()) >= opener_len
+                    or lines[j].strip() == fence_char[: len(lines[j].strip())]
+                ):
+                    closer_stripped = lines[j].strip()
+                    if closer_stripped == fence_char[: len(closer_stripped)]:
+                        pass
+                    elif closer_stripped.startswith(fence_char):
+                        break
+                body_lines.append(lines[j])
+                j += 1
+
+            escaped_content = html_escape("\n".join(body_lines))
+            html = (
+                f'<div class="callout callout--{lang}">'
+                f'<span class="callout__icon">{icon}</span>'
+                f'<span class="callout__body">{escaped_content}</span>'
+                f"</div>"
+            )
+            result.append(html)
+            i = j + 1
+
+        return result
+
+
+class CalloutExtension(Extension):
+    """Markdown extension for callout blocks using fenced code syntax."""
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            CalloutBlockPreprocessor(md),
+            "callout",
+            27,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # RecentChanges macro
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -1566,6 +1642,7 @@ def create_parser(
                 include_chain=include_chain or [],
             ),  # <<Include(...)>>
             NewPageExtension(),  # <<NewPage(...)>>
+            CalloutExtension(),  # callout blocks
         ]
     )
 

--- a/src/meshwiki/static/css/style.css
+++ b/src/meshwiki/static/css/style.css
@@ -2025,3 +2025,99 @@ article.page > .breadcrumb {
     line-height: 1.4;
 }
 .new-page-button:hover { background: var(--color-bg-secondary, #f5f5f5); }
+
+/* === Callout Blocks === */
+.callout {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.9rem 1.1rem;
+  border-radius: 6px;
+  border-left: 4px solid;
+  margin: 1rem 0;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+.callout__icon { font-size: 1.2rem; flex-shrink: 0; }
+.callout__body { flex: 1; white-space: pre-wrap; }
+
+.callout--info {
+  --callout-info-bg: #e8f4fd;
+  --callout-info-border: #2196f3;
+  --callout-info-color: #0d47a1;
+  background: var(--callout-info-bg);
+  border-color: var(--callout-info-border);
+  color: var(--callout-info-color);
+}
+
+.callout--warning {
+  --callout-warning-bg: #fff8e1;
+  --callout-warning-border: #ffc107;
+  --callout-warning-color: #7b5e00;
+  background: var(--callout-warning-bg);
+  border-color: var(--callout-warning-border);
+  color: var(--callout-warning-color);
+}
+
+.callout--tip {
+  --callout-tip-bg: #e8f5e9;
+  --callout-tip-border: #4caf50;
+  --callout-tip-color: #1b5e20;
+  background: var(--callout-tip-bg);
+  border-color: var(--callout-tip-border);
+  color: var(--callout-tip-color);
+}
+
+.callout--error {
+  --callout-error-bg: #fdecea;
+  --callout-error-border: #f44336;
+  --callout-error-color: #b71c1c;
+  background: var(--callout-error-bg);
+  border-color: var(--callout-error-border);
+  color: var(--callout-error-color);
+}
+
+.callout--note {
+  --callout-note-bg: #f5f5f5;
+  --callout-note-border: #9e9e9e;
+  --callout-note-color: #424242;
+  background: var(--callout-note-bg);
+  border-color: var(--callout-note-border);
+  color: var(--callout-note-color);
+}
+
+[data-theme="dark"] .callout--info {
+  --callout-info-bg: #0d2137;
+  --callout-info-border: #42a5f5;
+  --callout-info-color: #90caf9;
+}
+
+[data-theme="dark"] .callout--warning {
+  --callout-warning-bg: #2a2000;
+  --callout-warning-border: #ffca28;
+  --callout-warning-color: #ffe082;
+}
+
+[data-theme="dark"] .callout--tip {
+  --callout-tip-bg: #0a2e0a;
+  --callout-tip-border: #66bb6a;
+  --callout-tip-color: #a5d6a7;
+}
+
+[data-theme="dark"] .callout--error {
+  --callout-error-bg: #2c0a0a;
+  --callout-error-border: #ef5350;
+  --callout-error-color: #ef9a9a;
+}
+
+[data-theme="dark"] .callout--note {
+  --callout-note-bg: #1e1e1e;
+  --callout-note-border: #bdbdbd;
+  --callout-note-color: #e0e0e0;
+}
+
+@media (max-width: 768px) {
+  .callout { font-size: 0.9rem; padding: 0.75rem 0.9rem; }
+}

--- a/src/tests/test_parser.py
+++ b/src/tests/test_parser.py
@@ -344,3 +344,84 @@ modified: '2026-01-02'
 This is body text with five words.
 """
         assert word_count(content) == 7
+
+
+# ============================================================
+# Callout Blocks
+# ============================================================
+
+
+class TestCalloutBlocks:
+    @pytest.mark.parametrize(
+        "lang,icon",
+        [
+            ("info", "\u2139\ufe0f"),
+            ("warning", "\u26a0\ufe0f"),
+            ("tip", "\ud83d\udca1"),
+            ("error", "\u274c"),
+            ("note", "\ud83d\udcdd"),
+        ],
+    )
+    def test_callout_type_renders_correctly(self, lang, icon):
+        content = f"```{lang}\nSome message\n```"
+        html = parse_wiki_content(content)
+        assert f"callout--{lang}" in html
+        assert icon in html
+        assert "Some message" in html
+
+    def test_callout_with_markdown_content(self):
+        content = "```info\nThis has **bold** text\n```"
+        html = parse_wiki_content(content)
+        assert "callout--info" in html
+        assert "This has **bold** text" in html
+
+    def test_multiple_callouts_same_page(self):
+        content = "```info\nFirst callout\n```\n\n```warning\nSecond callout\n```"
+        html = parse_wiki_content(content)
+        assert html.count("callout--") == 2
+        assert "callout--info" in html
+        assert "callout--warning" in html
+        assert "First callout" in html
+        assert "Second callout" in html
+
+    def test_non_callout_fenced_code_unaffected(self):
+        content = "```python\nprint('hello')\n```"
+        html = parse_wiki_content(content)
+        assert "callout" not in html
+        assert "<code" in html
+        assert "print" in html
+
+    def test_callout_tilde_fence(self):
+        content = "~~~note\nSome note text\n~~~"
+        html = parse_wiki_content(content)
+        assert "callout--note" in html
+        assert "Some note text" in html
+
+    def test_callout_content_html_escaped(self):
+        content = "```error\n<script>alert('xss')</script>\n```"
+        html = parse_wiki_content(content)
+        assert "callout--error" in html
+        assert "&lt;script&gt;" in html
+        assert "<script>alert" not in html
+
+    def test_callout_in_full_page_content(self):
+        content = "# Title\n\n```tip\nUse this tip\n```\n\nSome paragraph."
+        html = parse_wiki_content(content)
+        assert "<h1" in html
+        assert "callout--tip" in html
+        assert "Use this tip" in html
+        assert "Some paragraph" in html
+
+    def test_unknown_language_not_callout(self):
+        content = "```infoooo\nSome text\n```"
+        html = parse_wiki_content(content)
+        assert "callout" not in html
+
+    def test_callout_with_empty_body(self):
+        content = "```info\n\n```"
+        html = parse_wiki_content(content)
+        assert "callout--info" in html
+
+    def test_callout_extension_registered(self):
+        parser = create_parser()
+        assert "callout" in parser.preprocessors


### PR DESCRIPTION
## Summary
- Add `CalloutBlockPreprocessor` to intercept fenced code blocks with callout type tags (info, warning, tip, error, note)
- Convert them to styled callout HTML divs with icons
- Register `CalloutExtension` with priority 27 (before fenced_code at 25)
- Add CSS with light/dark mode support and mobile responsive styles
- Add 14 unit tests covering all callout types, multiple callouts, HTML escaping, tilde fences

## Files Changed
- `src/meshwiki/core/parser.py` - CalloutBlockPreprocessor + CalloutExtension
- `src/meshwiki/static/css/style.css` - Callout block styles
- `src/tests/test_parser.py` - Unit tests

## Test Results
All 57 parser tests pass including 14 new callout tests.