### PR TITLE
[Factory] CalloutBlockPreprocessor and CSS

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -1514,6 +1514,69 @@ class EpicStatusExtension(Extension):
         )
 
 
+CALLOUT_TYPES = ["info", "warning", "tip", "error", "note"]
+
+CALLOUT_ICONS: dict[str, str] = {
+    "info": "ℹ️",
+    "warning": "⚠️",
+    "tip": "💡",
+    "error": "❌",
+    "note": "📝",
+}
+
+
+class CalloutBlockPreprocessor(Preprocessor):
+    """Preprocessor that replaces fenced code blocks with callout type with HTML callout boxes."""
+
+    FENCE_RE = re.compile(r"^(```|~~~)\s*(\w+)\s*$")
+
+    def run(self, lines: list[str]) -> list[str]:
+        result: list[str] = []
+        i = 0
+        while i < len(lines):
+            m = self.FENCE_RE.match(lines[i])
+            if not m or m.group(2) not in CALLOUT_TYPES:
+                result.append(lines[i])
+                i += 1
+                continue
+
+            fence_char = m.group(1)
+            callout_type = m.group(2)
+            body_lines: list[str] = []
+            j = i + 1
+            while j < len(lines):
+                if lines[j].startswith(fence_char) and lines[j].strip() in (
+                    fence_char,
+                ):
+                    break
+                body_lines.append(lines[j])
+                j += 1
+
+            if j >= len(lines):
+                result.append(lines[i])
+                i += 1
+                continue
+
+            escaped = html_escape("\n".join(body_lines))
+            icon = CALLOUT_ICONS[callout_type]
+            html = f'<div class="callout callout--{callout_type}"><span class="callout__icon">{icon}</span><span class="callout__body">{escaped}</span></div>'
+            result.append(self.md.htmlStash.store(html))
+            i = j + 1
+
+        return result
+
+
+class CalloutExtension(Extension):
+    """Markdown extension for callout blocks using fenced code syntax."""
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            CalloutBlockPreprocessor(md),
+            "callout",
+            27,
+        )
+
+
 def create_parser(
     page_exists: Callable[[str], bool] | None = None,
     page_name: str | None = None,
@@ -1557,6 +1620,7 @@ def create_parser(
             EpicStatusExtension(
                 page_name=page_name, page_metadata=page_metadata
             ),  # <<EpicStatus>>
+            CalloutExtension(),  # ```info``` etc. callout blocks
             RecentChangesExtension(recent_pages=recent_pages),  # <<RecentChanges(n)>>
             PageCountExtension(),  # <<PageCount>>
             BackLinksExtension(page_name=page_name),  # <<BackLinks>>

--- a/src/meshwiki/static/css/style.css
+++ b/src/meshwiki/static/css/style.css
@@ -2025,3 +2025,94 @@ article.page > .breadcrumb {
     line-height: 1.4;
 }
 .new-page-button:hover { background: var(--color-bg-secondary, #f5f5f5); }
+
+/* === Callout Blocks === */
+.callout {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.9rem 1.1rem;
+  border-radius: 6px;
+  border-left: 4px solid;
+  margin: 1rem 0;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+.callout__icon { font-size: 1.2rem; flex-shrink: 0; }
+.callout__body { flex: 1; white-space: pre-wrap; }
+
+/* Light mode */
+.callout--info {
+  --callout-info-bg: #e8f4fd;
+  --callout-info-border: #2196f3;
+  --callout-info-color: #0d47a1;
+  background: var(--callout-info-bg);
+  border-color: var(--callout-info-border);
+  color: var(--callout-info-color);
+}
+.callout--warning {
+  --callout-warning-bg: #fff8e1;
+  --callout-warning-border: #ffc107;
+  --callout-warning-color: #7b5e00;
+  background: var(--callout-warning-bg);
+  border-color: var(--callout-warning-border);
+  color: var(--callout-warning-color);
+}
+.callout--tip {
+  --callout-tip-bg: #e8f5e9;
+  --callout-tip-border: #4caf50;
+  --callout-tip-color: #1b5e20;
+  background: var(--callout-tip-bg);
+  border-color: var(--callout-tip-border);
+  color: var(--callout-tip-color);
+}
+.callout--error {
+  --callout-error-bg: #fdecea;
+  --callout-error-border: #f44336;
+  --callout-error-color: #b71c1c;
+  background: var(--callout-error-bg);
+  border-color: var(--callout-error-border);
+  color: var(--callout-error-color);
+}
+.callout--note {
+  --callout-note-bg: #f5f5f5;
+  --callout-note-border: #9e9e9e;
+  --callout-note-color: #424242;
+  background: var(--callout-note-bg);
+  border-color: var(--callout-note-border);
+  color: var(--callout-note-color);
+}
+
+/* Dark mode */
+[data-theme="dark"] .callout--info {
+  --callout-info-bg: #0d2137;
+  --callout-info-border: #42a5f5;
+  --callout-info-color: #90caf9;
+}
+[data-theme="dark"] .callout--warning {
+  --callout-warning-bg: #2a2000;
+  --callout-warning-border: #ffca28;
+  --callout-warning-color: #ffe082;
+}
+[data-theme="dark"] .callout--tip {
+  --callout-tip-bg: #0a2e0a;
+  --callout-tip-border: #66bb6a;
+  --callout-tip-color: #a5d6a7;
+}
+[data-theme="dark"] .callout--error {
+  --callout-error-bg: #2c0a0a;
+  --callout-error-border: #ef5350;
+  --callout-error-color: #ef9a9a;
+}
+[data-theme="dark"] .callout--note {
+  --callout-note-bg: #1e1e1e;
+  --callout-note-border: #bdbdbd;
+  --callout-note-color: #e0e0e0;
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .callout { font-size: 0.9rem; padding: 0.75rem 0.9rem; }
+}

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Shared fixtures for integration tests."""
+
+import os
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+pytest_plugins = ["pytest_asyncio"]
+
+
+@pytest.fixture()
+def wiki_app(tmp_path):
+    """Create a fresh app instance pointing at a temp directory.
+
+    Reloads config and main modules so the app picks up the temp
+    data_dir. Yields the FastAPI app object.
+    """
+    import importlib
+
+    os.environ["MESHWIKI_DATA_DIR"] = str(tmp_path)
+
+    import meshwiki.config
+
+    importlib.reload(meshwiki.config)
+    import meshwiki.main
+
+    importlib.reload(meshwiki.main)
+
+    yield meshwiki.main.app
+
+    os.environ.pop("MESHWIKI_DATA_DIR", None)
+
+
+@pytest_asyncio.fixture()
+async def client(wiki_app):
+    """Async HTTP client wired to the app (no lifespan)."""
+    transport = ASGITransport(app=wiki_app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+    ) as c:
+        yield c

--- a/src/tests/test_callout_macro.py
+++ b/src/tests/test_callout_macro.py
@@ -1,0 +1,213 @@
+"""Tests for CalloutBlockPreprocessor and CalloutExtension."""
+
+import pytest
+
+from meshwiki.core.parser import (
+    CALLOUT_ICONS,
+    CALLOUT_TYPES,
+    parse_wiki_content,
+)
+
+
+class TestCalloutBlockPreprocessor:
+    """Unit tests for CalloutBlockPreprocessor using full Markdown conversion."""
+
+    @pytest.mark.parametrize("callout_type", CALLOUT_TYPES)
+    def test_each_type_renders_correct_class_and_icon(self, callout_type):
+        """Each of the 5 types renders correct class and icon."""
+        content = f"""```{callout_type}
+This is the callout body
+with multiple lines
+```"""
+        html = parse_wiki_content(content)
+        assert f'class="callout callout--{callout_type}"' in html
+        assert (
+            f'<span class="callout__icon">{CALLOUT_ICONS[callout_type]}</span>' in html
+        )
+        assert "This is the callout body" in html
+
+    def test_regular_code_block_untouched(self):
+        """A regular code block (e.g. ```python) is not affected."""
+        content = """```python
+def hello():
+    print("world")
+```"""
+        html = parse_wiki_content(content)
+        assert '<code class="language-python"' in html or "<code>" in html
+        assert "def hello():" in html
+        assert "print" in html
+        assert 'class="callout' not in html
+
+    def test_tilde_fence_callout(self):
+        """Callout blocks using ~~~ fence are also detected."""
+        content = """~~~info
+This is a tilde callout
+~~~"""
+        html = parse_wiki_content(content)
+        assert 'class="callout callout--info"' in html
+        assert '<span class="callout__icon">ℹ️</span>' in html
+
+    def test_multiple_callouts_same_page(self):
+        """Multiple callouts on the same page all render correctly."""
+        content = """```info
+First callout
+```
+
+Some text between
+
+```warning
+Second callout
+```
+
+```tip
+Third callout
+```"""
+        html = parse_wiki_content(content)
+        assert 'class="callout callout--info"' in html
+        assert "First callout" in html
+        assert 'class="callout callout--warning"' in html
+        assert "Second callout" in html
+        assert 'class="callout callout--tip"' in html
+        assert "Third callout" in html
+
+    def test_unclosed_fence_passed_through(self):
+        """An unclosed callout fence is passed through unchanged."""
+        content = """```info
+This callout is never closed"""
+        html = parse_wiki_content(content)
+        assert 'class="callout' not in html
+
+    def test_html_escaping_in_body(self):
+        """HTML special characters in callout body are escaped."""
+        content = """```info
+Use <script>alert('xss')</script> and &amp;
+```"""
+        html = parse_wiki_content(content)
+        assert "&lt;script&gt;" in html
+        assert "&amp;amp;" in html
+        assert 'class="callout callout--info"' in html
+
+    def test_empty_callout_body(self):
+        """An empty callout body renders correctly."""
+        content = """```note
+```"""
+        html = parse_wiki_content(content)
+        assert 'class="callout callout--note"' in html
+        assert '<span class="callout__icon">📝</span>' in html
+
+    def test_code_block_not_callout_type(self):
+        """Language tags that are not callout types are not intercepted."""
+        content = """```javascript
+console.log('hello');
+```"""
+        html = parse_wiki_content(content)
+        assert 'class="callout' not in html
+        assert "console.log" in html
+
+    def test_nested_code_like_in_body(self):
+        """Content that looks like a fence inside the callout body is preserved."""
+        content = """```info
+Here is some ``` code
+```"""
+        html = parse_wiki_content(content)
+        assert 'class="callout callout--info"' in html
+        assert "Here is some ``` code" in html
+
+
+class TestCalloutIntegration:
+    """Integration tests for callout blocks via HTTP route."""
+
+    @pytest.mark.asyncio
+    async def test_callout_via_http_route(self, client):
+        """Callout inside a page renders correctly via the HTTP route."""
+        page_content = """
+```info
+This is an info callout
+```
+
+Some text
+
+```warning
+This is a warning callout
+```
+"""
+        resp = await client.post("/page/CalloutTest", data={"content": page_content})
+        assert resp.status_code == 200
+
+        resp = await client.get("/page/CalloutTest")
+        assert resp.status_code == 200
+        html = resp.text
+        assert 'class="callout callout--info"' in html
+        assert 'class="callout callout--warning"' in html
+        assert "This is an info callout" in html
+        assert "This is a warning callout" in html
+
+
+class TestCalloutCSS:
+    """Tests for callout CSS variables in style.css."""
+
+    def test_dark_mode_css_variables_present(self):
+        """Dark mode CSS variables are present in style.css."""
+        import os
+
+        style_css_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "meshwiki",
+            "static",
+            "css",
+            "style.css",
+        )
+        with open(style_css_path, "r") as f:
+            css = f.read()
+
+        assert '[data-theme="dark"] .callout--info' in css
+        assert "--callout-info-bg:" in css
+        assert "--callout-info-border:" in css
+        assert "--callout-info-color:" in css
+
+        assert '[data-theme="dark"] .callout--warning' in css
+        assert '[data-theme="dark"] .callout--tip' in css
+        assert '[data-theme="dark"] .callout--error' in css
+        assert '[data-theme="dark"] .callout--note' in css
+
+    def test_light_mode_css_variables_present(self):
+        """Light mode CSS variables are present in style.css."""
+        import os
+
+        style_css_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "meshwiki",
+            "static",
+            "css",
+            "style.css",
+        )
+        with open(style_css_path, "r") as f:
+            css = f.read()
+
+        assert ".callout--info" in css
+        assert "--callout-info-bg:" in css
+        assert ".callout--warning" in css
+        assert ".callout--tip" in css
+        assert ".callout--error" in css
+        assert ".callout--note" in css
+
+    def test_callout_base_styles_present(self):
+        """Base .callout and .callout__icon, .callout__body styles are present."""
+        import os
+
+        style_css_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "meshwiki",
+            "static",
+            "css",
+            "style.css",
+        )
+        with open(style_css_path, "r") as f:
+            css = f.read()
+
+        assert ".callout {" in css
+        assert ".callout__icon {" in css
+        assert ".callout__body {" in css


### PR DESCRIPTION
## Summary
- Add `CalloutBlockPreprocessor` that intercepts fenced code blocks with callout types (`info`, `warning`, `tip`, `error`, `note`) and replaces them with styled HTML divs
- Add `CalloutExtension` registered at priority 27 (before fenced_code at 25)
- Add comprehensive CSS for callout blocks with light/dark mode support
- Add 17 tests covering all callout types, regular code block passthrough, multiple callouts, HTML escaping, unclosed fence handling, and CSS variable verification
- Add `conftest.py` with shared fixtures (`wiki_app`, `client`) for integration tests

## Files Changed
- `src/meshwiki/core/parser.py` - Added CalloutBlockPreprocessor and CalloutExtension
- `src/meshwiki/static/css/style.css` - Added callout block CSS
- `src/tests/test_callout_macro.py` - New test file with 17 tests
- `src/tests/conftest.py` - Shared fixtures for integration tests