### PR TITLE
[Factory] Tests for CalloutBlockPreprocessor

### DIFF
--- a/src/tests/test_callout_macro.py
+++ b/src/tests/test_callout_macro.py
@@ -1,38 +1,30 @@
-"""Unit tests for the CalloutBlockPreprocessor feature.
+"""Unit and integration tests for CalloutBlockPreprocessor."""
 
-Tests fenced code blocks with callout language tags (```info, ```warning, etc.)
-are rendered as styled callout boxes with appropriate icons.
-
-Depends on: TASK001 (CalloutBlockPreprocessor implementation)
-"""
-
-import re
+import asyncio
 from pathlib import Path
 
 import pytest
+from starlette.testclient import TestClient
 
 from meshwiki.core.parser import create_parser
 
 
-CALLOUT_TYPES = {
-    "info": "ℹ️",
-    "warning": "⚠️",
-    "tip": "💡",
-    "error": "❌",
-    "note": "📝",
-}
-
-
 @pytest.fixture(scope="module")
 def css_content() -> str:
+    """Read style.css once for the entire test module."""
     css_path = (
         Path(__file__).parent.parent / "meshwiki" / "static" / "css" / "style.css"
     )
     return css_path.read_text()
 
 
+# ============================================================
+# Unit tests for callout rendering
+# ============================================================
+
+
 def test_info_callout_renders() -> None:
-    """```info\n...\n``` renders as a callout with info styling."""
+    """```info\\n...``` renders as a callout with info styling."""
     html = create_parser().convert("```info\nThis is an info message.\n```")
     assert 'class="callout callout--info"' in html
     assert "ℹ️" in html
@@ -40,179 +32,281 @@ def test_info_callout_renders() -> None:
 
 
 def test_warning_callout_renders() -> None:
-    """```warning\n...\n``` renders as a callout with warning styling."""
-    html = create_parser().convert("```warning\nWatch out!\n```")
+    """```warning\\n...``` renders as a callout with warning styling."""
+    html = create_parser().convert("```warning\nThis is a warning message.\n```")
     assert 'class="callout callout--warning"' in html
     assert "⚠️" in html
-    assert "Watch out" in html
+    assert "This is a warning message" in html
 
 
 def test_tip_callout_renders() -> None:
-    """```tip\n...\n``` renders as a callout with tip styling."""
-    html = create_parser().convert("```tip\nPro tip: use the force.\n```")
+    """```tip\\n...``` renders as a callout with tip styling."""
+    html = create_parser().convert("```tip\nThis is a tip.\n```")
     assert 'class="callout callout--tip"' in html
     assert "💡" in html
-    assert "Pro tip: use the force" in html
+    assert "This is a tip" in html
 
 
 def test_error_callout_renders() -> None:
-    """```error\n...\n``` renders as a callout with error styling."""
-    html = create_parser().convert("```error\nSomething went wrong.\n```")
+    """```error\\n...``` renders as a callout with error styling."""
+    html = create_parser().convert("```error\nThis is an error.\n```")
     assert 'class="callout callout--error"' in html
     assert "❌" in html
-    assert "Something went wrong" in html
+    assert "This is an error" in html
 
 
 def test_note_callout_renders() -> None:
-    """```note\n...\n``` renders as a callout with note styling."""
-    html = create_parser().convert("```note\nRemember this.\n```")
+    """```note\\n...``` renders as a callout with note styling."""
+    html = create_parser().convert("```note\nThis is a note.\n```")
     assert 'class="callout callout--note"' in html
     assert "📝" in html
-    assert "Remember this" in html
+    assert "This is a note" in html
 
 
 def test_python_code_block_not_affected() -> None:
-    """```python\n...\n``` renders as a normal code block, not a callout."""
+    """Regular ```python\\n...``` code blocks are NOT treated as callouts."""
     html = create_parser().convert('```python\nprint("hello")\n```')
     assert 'class="callout"' not in html
     assert "<code" in html
 
 
-def test_javascript_code_block_not_affected() -> None:
-    """```javascript\n...\n``` renders as a normal code block."""
-    html = create_parser().convert("```javascript\nconst x = 1;\n```")
-    assert 'class="callout"' not in html
-    assert "<code" in html
-
-
-def test_generic_fence_not_affected() -> None:
-    """```text\n...\n``` renders as a normal code block."""
-    html = create_parser().convert("```text\nSome text content.\n```")
-    assert 'class="callout"' not in html
-    assert "Some text content" in html
-
-
-def test_multiple_different_callout_types() -> None:
-    """Multiple callout blocks of different types appear in correct order."""
-    content = "\n\n".join(
-        [
-            "```info\nFirst info.\n```",
-            "```warning\nThen warning.\n```",
-            "```tip\nFinally tip.\n```",
-        ]
-    )
+def test_multiple_callouts_on_same_page() -> None:
+    """Multiple callout blocks of different types render in order."""
+    content = """```info
+First info callout
+```
+Some text in between.
+```warning
+Warning callout here
+```
+More text.
+```tip
+A tip callout
+```"""
     html = create_parser().convert(content)
-
+    assert html.count("callout--info") == 1
+    assert html.count("callout--warning") == 1
+    assert html.count("callout--tip") == 1
+    assert "First info callout" in html
+    assert "Warning callout here" in html
+    assert "A tip callout" in html
     info_pos = html.find("callout--info")
     warning_pos = html.find("callout--warning")
     tip_pos = html.find("callout--tip")
-
-    assert info_pos != -1, "Info callout not found"
-    assert warning_pos != -1, "Warning callout not found"
-    assert tip_pos != -1, "Tip callout not found"
-    assert info_pos < warning_pos < tip_pos, "Callouts not in correct order"
+    assert info_pos < warning_pos < tip_pos, "Callouts should appear in source order"
 
 
-def test_multiple_same_callout_type() -> None:
-    """Multiple callout blocks of the same type both render."""
-    content = "\n\n".join(
-        [
-            "```info\nFirst info message.\n```",
-            "```info\nSecond info message.\n```",
-        ]
-    )
-    html = create_parser().convert(content)
-    assert html.count("callout--info") == 2
-    assert "First info message" in html
-    assert "Second info message" in html
-
-
-def test_script_tag_escaped() -> None:
-    """<script>alert(1)</script> in callout body is HTML-escaped."""
+def test_callout_content_is_html_escaped() -> None:
+    """Callout body content is HTML-escaped to prevent XSS."""
     html = create_parser().convert("```warning\n<script>alert(1)</script>\n```")
-    assert "<script>" not in html
+    assert "callout--warning" in html
     assert "&lt;script&gt;" in html
+    assert "<script>" not in html
 
 
-def test_html_tags_escaped() -> None:
-    """Raw HTML tags in callout body are escaped."""
-    html = create_parser().convert("```error\n<div>hello</div>\n```")
-    assert "<div>hello</div>" not in html
-    assert "&lt;div&gt;hello&lt;/div&gt;" in html
-
-
-def test_tilde_warning_callout() -> None:
-    """~~~warning\n...\n~~~ renders as a callout."""
+def test_tilde_fence_style() -> None:
+    """Callout blocks also work with ~~~ fence style."""
     html = create_parser().convert("~~~warning\nWatch out!\n~~~")
     assert 'class="callout callout--warning"' in html
     assert "⚠️" in html
-    assert "Watch out" in html
+    assert "Watch out!" in html
 
 
-def test_tilde_info_callout() -> None:
-    """~~~info\n...\n~~~ renders as a callout."""
-    html = create_parser().convert("~~~info\nInfo message.\n~~~")
-    assert 'class="callout callout--info"' in html
-    assert "ℹ️" in html
+def test_callout_with_multiple_lines() -> None:
+    """Callout body can span multiple lines."""
+    content = """```info
+Line one
+Line two
+Line three
+```"""
+    html = create_parser().convert(content)
+    assert "callout--info" in html
+    assert "Line one" in html
+    assert "Line two" in html
+    assert "Line three" in html
 
 
-def test_tilde_tip_callout() -> None:
-    """~~~tip\n...\n~~~ renders as a callout."""
-    html = create_parser().convert("~~~tip\nPro tip.\n~~~")
-    assert 'class="callout callout--tip"' in html
-    assert "💡" in html
+def test_mixed_callouts_and_code_blocks() -> None:
+    """Regular code blocks and callouts can coexist on the same page."""
+    content = """```python
+def hello():
+    print("world")
+```
+```info
+This is info
+```
+```tip
+And a tip
+```"""
+    html = create_parser().convert(content)
+    assert "callout--info" in html
+    assert "callout--tip" in html
+    assert "def hello" in html
+
+
+def test_unclosed_callout_passes_through() -> None:
+    """Unclosed callout blocks are not rendered as callouts."""
+    content = """```info
+This callout has no closing fence
+just some text"""
+    html = create_parser().convert(content)
+    assert "callout--info" not in html
+    assert "This callout has no closing fence" in html
+
+
+def test_callout_type_not_case_sensitive() -> None:
+    """Callout type must be lowercase to be recognized."""
+    html = create_parser().convert("```INFO\nShould not match\n```")
+    assert "callout--INFO" not in html
+    assert "callout--info" not in html
+
+
+# ============================================================
+# Integration tests via HTTP
+# ============================================================
+
+
+def test_warning_callout_via_http(tmp_path) -> None:
+    """A wiki page with a warning callout renders the callout styling via HTTP."""
+    import os
+
+    import meshwiki.config
+    import meshwiki.main
+
+    importlib = __import__("importlib")
+
+    os.environ["MESHWIKI_DATA_DIR"] = str(tmp_path)
+    importlib.reload(meshwiki.config)
+    importlib.reload(meshwiki.main)
+
+    asyncio.run(
+        meshwiki.main.storage.save_page(
+            "CalloutTestPage", "```warning\nThis is a warning message.\n```"
+        )
+    )
+
+    with TestClient(meshwiki.main.app) as client:
+        resp = client.get("/page/CalloutTestPage")
+        assert resp.status_code == 200
+        assert "callout--warning" in resp.text
+        assert "⚠️" in resp.text
+
+    os.environ.pop("MESHWIKI_DATA_DIR", None)
+
+
+def test_info_callout_via_http(tmp_path) -> None:
+    """A wiki page with an info callout renders correctly via HTTP."""
+    import os
+
+    import meshwiki.config
+    import meshwiki.main
+
+    importlib = __import__("importlib")
+
+    os.environ["MESHWIKI_DATA_DIR"] = str(tmp_path)
+    importlib.reload(meshwiki.config)
+    importlib.reload(meshwiki.main)
+
+    asyncio.run(
+        meshwiki.main.storage.save_page(
+            "InfoCalloutPage", "```info\nThis is an info message.\n```"
+        )
+    )
+
+    with TestClient(meshwiki.main.app) as client:
+        resp = client.get("/page/InfoCalloutPage")
+        assert resp.status_code == 200
+        assert "callout--info" in resp.text
+        assert "ℹ️" in resp.text
+
+    os.environ.pop("MESHWIKI_DATA_DIR", None)
+
+
+def test_multiple_callouts_via_http(tmp_path) -> None:
+    """Multiple callouts on one page render correctly via HTTP."""
+    import os
+
+    import meshwiki.config
+    import meshwiki.main
+
+    importlib = __import__("importlib")
+
+    os.environ["MESHWIKI_DATA_DIR"] = str(tmp_path)
+    importlib.reload(meshwiki.config)
+    importlib.reload(meshwiki.main)
+
+    content = """```info
+First info
+```
+```warning
+A warning
+```
+```tip
+And a tip
+```"""
+    asyncio.run(meshwiki.main.storage.save_page("MultiCalloutPage", content))
+
+    with TestClient(meshwiki.main.app) as client:
+        resp = client.get("/page/MultiCalloutPage")
+        assert resp.status_code == 200
+        assert "callout--info" in resp.text
+        assert "callout--warning" in resp.text
+        assert "callout--tip" in resp.text
+        assert "ℹ️" in resp.text
+        assert "⚠️" in resp.text
+        assert "💡" in resp.text
+
+    os.environ.pop("MESHWIKI_DATA_DIR", None)
+
+
+# ============================================================
+# CSS presence tests
+# ============================================================
 
 
 def test_dark_mode_support(css_content: str) -> None:
-    """style.css contains [data-theme="dark"] for dark mode."""
+    """CSS contains dark mode support for callouts."""
     assert '[data-theme="dark"]' in css_content
 
 
-def test_callout_info_bg_css_variable(css_content: str) -> None:
-    """style.css contains --callout-info-bg custom property."""
+def test_callout_css_variables_present(css_content: str) -> None:
+    """CSS contains callout background color variables."""
     assert "--callout-info-bg" in css_content
-
-
-def test_callout_warning_bg_css_variable(css_content: str) -> None:
-    """style.css contains --callout-warning-bg custom property."""
     assert "--callout-warning-bg" in css_content
-
-
-def test_callout_tip_bg_css_variable(css_content: str) -> None:
-    """style.css contains --callout-tip-bg custom property."""
     assert "--callout-tip-bg" in css_content
-
-
-def test_callout_error_bg_css_variable(css_content: str) -> None:
-    """style.css contains --callout-error-bg custom property."""
     assert "--callout-error-bg" in css_content
-
-
-def test_callout_note_bg_css_variable(css_content: str) -> None:
-    """style.css contains --callout-note-bg custom property."""
     assert "--callout-note-bg" in css_content
 
 
-def test_callout_info_css_class(css_content: str) -> None:
-    """style.css contains .callout--info class."""
+def test_callout_dark_mode_variables(css_content: str) -> None:
+    """CSS contains dark mode callout color overrides."""
+    assert '[data-theme="dark"] .callout--info' in css_content
+    assert '[data-theme="dark"] .callout--warning' in css_content
+    assert '[data-theme="dark"] .callout--tip' in css_content
+    assert '[data-theme="dark"] .callout--error' in css_content
+    assert '[data-theme="dark"] .callout--note' in css_content
+
+
+def test_callout_info_class(css_content: str) -> None:
+    """CSS contains .callout--info class."""
     assert ".callout--info" in css_content
 
 
-def test_callout_warning_css_class(css_content: str) -> None:
-    """style.css contains .callout--warning class."""
+def test_callout_warning_class(css_content: str) -> None:
+    """CSS contains .callout--warning class."""
     assert ".callout--warning" in css_content
 
 
-def test_callout_tip_css_class(css_content: str) -> None:
-    """style.css contains .callout--tip class."""
+def test_callout_tip_class(css_content: str) -> None:
+    """CSS contains .callout--tip class."""
     assert ".callout--tip" in css_content
 
 
-def test_callout_error_css_class(css_content: str) -> None:
-    """style.css contains .callout--error class."""
+def test_callout_error_class(css_content: str) -> None:
+    """CSS contains .callout--error class."""
     assert ".callout--error" in css_content
 
 
-def test_callout_note_css_class(css_content: str) -> None:
-    """style.css contains .callout--note class."""
+def test_callout_note_class(css_content: str) -> None:
+    """CSS contains .callout--note class."""
     assert ".callout--note" in css_content

--- a/src/tests/test_callout_macro.py
+++ b/src/tests/test_callout_macro.py
@@ -1,197 +1,218 @@
-"""Unit and integration tests for CalloutBlockPreprocessor."""
+"""Unit tests for the CalloutBlockPreprocessor feature.
+
+Tests fenced code blocks with callout language tags (```info, ```warning, etc.)
+are rendered as styled callout boxes with appropriate icons.
+
+Depends on: TASK001 (CalloutBlockPreprocessor implementation)
+"""
+
+import re
+from pathlib import Path
 
 import pytest
 
-from meshwiki.core.parser import parse_wiki_content
+from meshwiki.core.parser import create_parser
 
 
-class TestCalloutBlockPreprocessor:
-    """Test CalloutBlockPreprocessor with fenced code blocks."""
+CALLOUT_TYPES = {
+    "info": "ℹ️",
+    "warning": "⚠️",
+    "tip": "💡",
+    "error": "❌",
+    "note": "📝",
+}
 
-    @pytest.mark.parametrize(
-        "callout_type,expected_class,expected_icon",
-        [
-            ("info", "callout--info", "ℹ️"),
-            ("warning", "callout--warning", "⚠️"),
-            ("tip", "callout--tip", "💡"),
-            ("error", "callout--error", "❌"),
-            ("note", "callout--note", "📝"),
-        ],
+
+@pytest.fixture(scope="module")
+def css_content() -> str:
+    css_path = (
+        Path(__file__).parent.parent / "meshwiki" / "static" / "css" / "style.css"
     )
-    def test_callout_renders_correct_class_and_icon(
-        self, callout_type: str, expected_class: str, expected_icon: str
-    ):
-        content = f"```{callout_type}\nThis is a {callout_type} callout.\n```"
-        html = parse_wiki_content(content)
-        assert expected_class in html
-        assert expected_icon in html
-        assert "callout__icon" in html
-        assert "callout__body" in html
-
-    def test_callout_with_multiple_lines(self):
-        content = """```info
-Line one
-Line two
-Line three
-```"""
-        html = parse_wiki_content(content)
-        assert "callout--info" in html
-        assert "Line one" in html
-        assert "Line two" in html
-        assert "Line three" in html
-
-    def test_regular_code_block_not_affected(self):
-        content = "```python\nprint('hello')\n```"
-        html = parse_wiki_content(content)
-        assert "callout" not in html
-        assert "print" in html
-
-    def test_tilde_fence_callout(self):
-        content = """~~~tip
-This is a tip.
-~~~"""
-        html = parse_wiki_content(content)
-        assert "callout--tip" in html
-        assert "This is a tip." in html
-
-    def test_multiple_callouts_on_same_page(self):
-        content = """```info
-First info callout
-```
-Some text in between.
-```warning
-Warning callout here
-```
-More text.
-```tip
-A tip callout
-```"""
-        html = parse_wiki_content(content)
-        assert html.count("callout--info") == 1
-        assert html.count("callout--warning") == 1
-        assert html.count("callout--tip") == 1
-        assert "First info callout" in html
-        assert "Warning callout here" in html
-        assert "A tip callout" in html
-
-    def test_mixed_callouts_and_code_blocks(self):
-        content = """```python
-def hello():
-    print("world")
-```
-```info
-This is info
-```
-```tip
-And a tip
-```"""
-        html = parse_wiki_content(content)
-        assert "callout--info" in html
-        assert "callout--tip" in html
-        assert "def hello" in html
-
-    def test_callout_content_is_html_escaped(self):
-        content = """```error
-<script>alert('xss')</script>
-```"""
-        html = parse_wiki_content(content)
-        assert "callout--error" in html
-        assert "&lt;script&gt;" in html
-        assert "<script>" not in html
-
-    def test_unclosed_callout_passes_through(self):
-        content = """```info
-This callout has no closing fence
-just some text"""
-        html = parse_wiki_content(content)
-        assert "callout--info" not in html
-        assert "This callout has no closing fence" in html
-
-    def test_callout_type_not_case_sensitive(self):
-        content = "```INFO\nShould not match\n```"
-        html = parse_wiki_content(content)
-        assert "callout--INFO" not in html
-        assert "callout--info" not in html
+    return css_path.read_text()
 
 
-class TestCalloutCSS:
-    """Test that callout CSS is present in style.css."""
-
-    def test_callout_css_variables_present(self):
-        import meshwiki
-
-        css_path = meshwiki.__file__.rsplit("/", 1)[0] + "/static/css/style.css"
-        with open(css_path) as f:
-            css_content = f.read()
-
-        assert "--callout-info-bg" in css_content
-        assert "--callout-warning-bg" in css_content
-        assert "--callout-tip-bg" in css_content
-        assert "--callout-error-bg" in css_content
-        assert "--callout-note-bg" in css_content
-
-    def test_dark_mode_callout_variables_present(self):
-        import meshwiki
-
-        css_path = meshwiki.__file__.rsplit("/", 1)[0] + "/static/css/style.css"
-        with open(css_path) as f:
-            css_content = f.read()
-
-        assert '[data-theme="dark"] .callout--info' in css_content
-        assert '[data-theme="dark"] .callout--warning' in css_content
-        assert '[data-theme="dark"] .callout--tip' in css_content
-        assert '[data-theme="dark"] .callout--error' in css_content
-        assert '[data-theme="dark"] .callout--note' in css_content
+def test_info_callout_renders() -> None:
+    """```info\n...\n``` renders as a callout with info styling."""
+    html = create_parser().convert("```info\nThis is an info message.\n```")
+    assert 'class="callout callout--info"' in html
+    assert "ℹ️" in html
+    assert "This is an info message" in html
 
 
-class TestCalloutViaHTTP:
-    """Integration tests for callouts via HTTP route."""
+def test_warning_callout_renders() -> None:
+    """```warning\n...\n``` renders as a callout with warning styling."""
+    html = create_parser().convert("```warning\nWatch out!\n```")
+    assert 'class="callout callout--warning"' in html
+    assert "⚠️" in html
+    assert "Watch out" in html
 
-    @pytest.mark.asyncio
-    async def test_callout_via_http_route(self, tmp_path):
-        from httpx import ASGITransport, AsyncClient
 
-        import meshwiki.main
+def test_tip_callout_renders() -> None:
+    """```tip\n...\n``` renders as a callout with tip styling."""
+    html = create_parser().convert("```tip\nPro tip: use the force.\n```")
+    assert 'class="callout callout--tip"' in html
+    assert "💡" in html
+    assert "Pro tip: use the force" in html
 
-        meshwiki.main.storage.base_path = tmp_path
-        await meshwiki.main.storage.save_page(
-            "CalloutTest", "```info\nThis is an info callout.\n```"
-        )
 
-        transport = ASGITransport(app=meshwiki.main.app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/page/CalloutTest")
+def test_error_callout_renders() -> None:
+    """```error\n...\n``` renders as a callout with error styling."""
+    html = create_parser().convert("```error\nSomething went wrong.\n```")
+    assert 'class="callout callout--error"' in html
+    assert "❌" in html
+    assert "Something went wrong" in html
 
-        assert resp.status_code == 200
-        assert "callout--info" in resp.text
-        assert "ℹ️" in resp.text
 
-    @pytest.mark.asyncio
-    async def test_multiple_callouts_via_http(self, tmp_path):
-        from httpx import ASGITransport, AsyncClient
+def test_note_callout_renders() -> None:
+    """```note\n...\n``` renders as a callout with note styling."""
+    html = create_parser().convert("```note\nRemember this.\n```")
+    assert 'class="callout callout--note"' in html
+    assert "📝" in html
+    assert "Remember this" in html
 
-        import meshwiki.main
 
-        meshwiki.main.storage.base_path = tmp_path
-        content = """```info
-First info
-```
-```warning
-A warning
-```
-```tip
-And a tip
-```"""
-        await meshwiki.main.storage.save_page("MultiCalloutTest", content)
+def test_python_code_block_not_affected() -> None:
+    """```python\n...\n``` renders as a normal code block, not a callout."""
+    html = create_parser().convert('```python\nprint("hello")\n```')
+    assert 'class="callout"' not in html
+    assert "<code" in html
 
-        transport = ASGITransport(app=meshwiki.main.app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/page/MultiCalloutTest")
 
-        assert resp.status_code == 200
-        assert "callout--info" in resp.text
-        assert "callout--warning" in resp.text
-        assert "callout--tip" in resp.text
-        assert "ℹ️" in resp.text
-        assert "⚠️" in resp.text
-        assert "💡" in resp.text
+def test_javascript_code_block_not_affected() -> None:
+    """```javascript\n...\n``` renders as a normal code block."""
+    html = create_parser().convert("```javascript\nconst x = 1;\n```")
+    assert 'class="callout"' not in html
+    assert "<code" in html
+
+
+def test_generic_fence_not_affected() -> None:
+    """```text\n...\n``` renders as a normal code block."""
+    html = create_parser().convert("```text\nSome text content.\n```")
+    assert 'class="callout"' not in html
+    assert "Some text content" in html
+
+
+def test_multiple_different_callout_types() -> None:
+    """Multiple callout blocks of different types appear in correct order."""
+    content = "\n\n".join(
+        [
+            "```info\nFirst info.\n```",
+            "```warning\nThen warning.\n```",
+            "```tip\nFinally tip.\n```",
+        ]
+    )
+    html = create_parser().convert(content)
+
+    info_pos = html.find("callout--info")
+    warning_pos = html.find("callout--warning")
+    tip_pos = html.find("callout--tip")
+
+    assert info_pos != -1, "Info callout not found"
+    assert warning_pos != -1, "Warning callout not found"
+    assert tip_pos != -1, "Tip callout not found"
+    assert info_pos < warning_pos < tip_pos, "Callouts not in correct order"
+
+
+def test_multiple_same_callout_type() -> None:
+    """Multiple callout blocks of the same type both render."""
+    content = "\n\n".join(
+        [
+            "```info\nFirst info message.\n```",
+            "```info\nSecond info message.\n```",
+        ]
+    )
+    html = create_parser().convert(content)
+    assert html.count("callout--info") == 2
+    assert "First info message" in html
+    assert "Second info message" in html
+
+
+def test_script_tag_escaped() -> None:
+    """<script>alert(1)</script> in callout body is HTML-escaped."""
+    html = create_parser().convert("```warning\n<script>alert(1)</script>\n```")
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_html_tags_escaped() -> None:
+    """Raw HTML tags in callout body are escaped."""
+    html = create_parser().convert("```error\n<div>hello</div>\n```")
+    assert "<div>hello</div>" not in html
+    assert "&lt;div&gt;hello&lt;/div&gt;" in html
+
+
+def test_tilde_warning_callout() -> None:
+    """~~~warning\n...\n~~~ renders as a callout."""
+    html = create_parser().convert("~~~warning\nWatch out!\n~~~")
+    assert 'class="callout callout--warning"' in html
+    assert "⚠️" in html
+    assert "Watch out" in html
+
+
+def test_tilde_info_callout() -> None:
+    """~~~info\n...\n~~~ renders as a callout."""
+    html = create_parser().convert("~~~info\nInfo message.\n~~~")
+    assert 'class="callout callout--info"' in html
+    assert "ℹ️" in html
+
+
+def test_tilde_tip_callout() -> None:
+    """~~~tip\n...\n~~~ renders as a callout."""
+    html = create_parser().convert("~~~tip\nPro tip.\n~~~")
+    assert 'class="callout callout--tip"' in html
+    assert "💡" in html
+
+
+def test_dark_mode_support(css_content: str) -> None:
+    """style.css contains [data-theme="dark"] for dark mode."""
+    assert '[data-theme="dark"]' in css_content
+
+
+def test_callout_info_bg_css_variable(css_content: str) -> None:
+    """style.css contains --callout-info-bg custom property."""
+    assert "--callout-info-bg" in css_content
+
+
+def test_callout_warning_bg_css_variable(css_content: str) -> None:
+    """style.css contains --callout-warning-bg custom property."""
+    assert "--callout-warning-bg" in css_content
+
+
+def test_callout_tip_bg_css_variable(css_content: str) -> None:
+    """style.css contains --callout-tip-bg custom property."""
+    assert "--callout-tip-bg" in css_content
+
+
+def test_callout_error_bg_css_variable(css_content: str) -> None:
+    """style.css contains --callout-error-bg custom property."""
+    assert "--callout-error-bg" in css_content
+
+
+def test_callout_note_bg_css_variable(css_content: str) -> None:
+    """style.css contains --callout-note-bg custom property."""
+    assert "--callout-note-bg" in css_content
+
+
+def test_callout_info_css_class(css_content: str) -> None:
+    """style.css contains .callout--info class."""
+    assert ".callout--info" in css_content
+
+
+def test_callout_warning_css_class(css_content: str) -> None:
+    """style.css contains .callout--warning class."""
+    assert ".callout--warning" in css_content
+
+
+def test_callout_tip_css_class(css_content: str) -> None:
+    """style.css contains .callout--tip class."""
+    assert ".callout--tip" in css_content
+
+
+def test_callout_error_css_class(css_content: str) -> None:
+    """style.css contains .callout--error class."""
+    assert ".callout--error" in css_content
+
+
+def test_callout_note_css_class(css_content: str) -> None:
+    """style.css contains .callout--note class."""
+    assert ".callout--note" in css_content


### PR DESCRIPTION
## Summary
- Add comprehensive test suite for CalloutBlockPreprocessor feature (TASK002)
- Tests cover all 5 callout types (info, warning, tip, error, note) with their icons
- Tests for regular code blocks not being affected
- Tests for multiple callouts on one page
- Tests for HTML escaping in callout bodies
- Tests for tilde fence style (~~~type)
- CSS presence tests for all callout styles and CSS variables
- Integration tests via HTTP using synchronous TestClient

## Changes
- Uses `create_parser().convert()` directly for unit tests (not `parse_wiki_content`)
- Top-level `def test_*()` functions, no classes
- All functions have `-> None` return type annotations
- Module-scoped `css_content` fixture for CSS tests
- Synchronous integration tests using `TestClient`

## Test Status
All 24 tests pass.