### PR TITLE
[Factory] Fix fan-in state merge bug in FactoryState

### DIFF
--- a/orchestrator/factory/state.py
+++ b/orchestrator/factory/state.py
@@ -20,6 +20,11 @@ def _merge_subtasks(current: list, update: list) -> list:
     return list(merged.values())
 
 
+def _union_ids(current: list[str], update: list[str]) -> list[str]:
+    """Union reducer for subtask ID lists (failed or completed)."""
+    return list(set(current) | set(update))
+
+
 class SubTask(TypedDict):
     """Represents a single unit of work assigned to a grinder agent."""
 
@@ -48,7 +53,9 @@ class SubTask(TypedDict):
     token_budget: int  # max tokens for the grinder session
     tokens_used: int
     review_feedback: str | None  # PM feedback for rejected subtasks
-    code_skeleton: str | None  # starter code template provided by PM during decomposition
+    code_skeleton: (
+        str | None
+    )  # starter code template provided by PM during decomposition
 
 
 class FactoryState(TypedDict):
@@ -66,8 +73,8 @@ class FactoryState(TypedDict):
 
     # Execution
     active_grinders: dict[str, str]  # subtask_id -> grinder session id
-    completed_subtask_ids: list[str]
-    failed_subtask_ids: list[str]
+    completed_subtask_ids: Annotated[list[str], _union_ids]
+    failed_subtask_ids: Annotated[list[str], _union_ids]
 
     # PM conversation history (accumulates via add_messages reducer)
     pm_messages: Annotated[list[BaseMessage], add_messages]

--- a/orchestrator/factory/state.py
+++ b/orchestrator/factory/state.py
@@ -53,9 +53,7 @@ class SubTask(TypedDict):
     token_budget: int  # max tokens for the grinder session
     tokens_used: int
     review_feedback: str | None  # PM feedback for rejected subtasks
-    code_skeleton: (
-        str | None
-    )  # starter code template provided by PM during decomposition
+    code_skeleton: str | None  # starter code template provided by PM during decomposition
 
 
 class FactoryState(TypedDict):

--- a/orchestrator/tests/test_state_reducers.py
+++ b/orchestrator/tests/test_state_reducers.py
@@ -1,0 +1,233 @@
+"""Tests for FactoryState reducers — especially fan-in merge behavior.
+
+When two parallel grinder branches write state concurrently, LangGraph fans in
+by applying each branch's updates through the field reducers.  These tests
+verify that the union reducers on completed_subtask_ids / failed_subtask_ids
+preserve both branches' writes and that the subtasks merge-by-ID reducer keeps
+the latest status per subtask.
+"""
+
+from __future__ import annotations
+
+from factory.state import (
+    FactoryState,
+    SubTask,
+    _merge_subtasks,
+    _union_ids,
+)
+
+# ---------------------------------------------------------------------------
+# Reducer unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_union_ids_merges_two_lists() -> None:
+    """Both branches' IDs survive the merge."""
+    result = _union_ids(["task-001", "task-002"], ["task-003", "task-001"])
+    assert set(result) == {"task-001", "task-002", "task-003"}
+
+
+def test_union_ids_handles_empty_lists() -> None:
+    """Empty input from one branch does not wipe the other branch's IDs."""
+    assert set(_union_ids([], ["task-001"])) == {"task-001"}
+    assert set(_union_ids(["task-002"], [])) == {"task-002"}
+    assert set(_union_ids([], [])) == set()
+
+
+def test_merge_subtasks_last_status_wins_per_id() -> None:
+    """When the same subtask ID appears in both lists, the latter wins."""
+    subtask_a = SubTask(
+        id="task-001",
+        wiki_page="Page1",
+        title="Title",
+        description="Desc",
+        status="failed",
+        assigned_grinder=None,
+        branch_name=None,
+        pr_url=None,
+        pr_number=None,
+        attempt=0,
+        max_attempts=3,
+        error_log=["error"],
+        files_touched=[],
+        token_budget=50000,
+        tokens_used=0,
+        review_feedback=None,
+        code_skeleton=None,
+    )
+    subtask_b = SubTask(
+        id="task-001",
+        wiki_page="Page1",
+        title="Title",
+        description="Desc",
+        status="merged",  # different status
+        assigned_grinder=None,
+        branch_name=None,
+        pr_url=None,
+        pr_number=None,
+        attempt=0,
+        max_attempts=3,
+        error_log=[],
+        files_touched=[],
+        token_budget=50000,
+        tokens_used=0,
+        review_feedback=None,
+        code_skeleton=None,
+    )
+    # current contains subtask_a, update contains subtask_b → b should win
+    result = _merge_subtasks([subtask_a], [subtask_b])
+    assert len(result) == 1
+    assert result[0]["status"] == "merged"
+
+
+def test_merge_subtasks_preserves_distinct_ids() -> None:
+    """Distinct IDs from both branches survive the merge."""
+    subtask_a = SubTask(
+        id="task-001",
+        wiki_page="Page1",
+        title="Title",
+        description="Desc",
+        status="failed",
+        assigned_grinder=None,
+        branch_name=None,
+        pr_url=None,
+        pr_number=None,
+        attempt=0,
+        max_attempts=3,
+        error_log=[],
+        files_touched=[],
+        token_budget=50000,
+        tokens_used=0,
+        review_feedback=None,
+        code_skeleton=None,
+    )
+    subtask_b = SubTask(
+        id="task-002",
+        wiki_page="Page2",
+        title="Title",
+        description="Desc",
+        status="merged",
+        assigned_grinder=None,
+        branch_name=None,
+        pr_url=None,
+        pr_number=None,
+        attempt=0,
+        max_attempts=3,
+        error_log=[],
+        files_touched=[],
+        token_budget=50000,
+        tokens_used=0,
+        review_feedback=None,
+        code_skeleton=None,
+    )
+    result = _merge_subtasks([subtask_a], [subtask_b])
+    assert len(result) == 2
+    ids = {r["id"] for r in result}
+    assert ids == {"task-001", "task-002"}
+
+
+# ---------------------------------------------------------------------------
+# Full state fan-in simulation
+# ---------------------------------------------------------------------------
+
+
+def test_fanin_preserves_failed_and_completed_subtask_ids() -> None:
+    """Simulate two parallel branch writes merging through union reducers.
+
+    Branch A writes failed_subtask_ids=["task-001"].
+    Branch B writes completed_subtask_ids=["task-002"].
+
+    After fan-in, both IDs must be present in the merged state.
+    """
+    base_state: FactoryState = {
+        "thread_id": "Task_0042",
+        "task_wiki_page": "Task_0042",
+        "title": "Test",
+        "requirements": "Test reqs",
+        "subtasks": [],
+        "decomposition_approved": True,
+        "active_grinders": {},
+        "completed_subtask_ids": [],  # no reducer needed for base state
+        "failed_subtask_ids": [],  # no reducer needed for base state
+        "pm_messages": [],
+        "human_approval_response": None,
+        "human_feedback": None,
+        "cost_usd": 0.0,
+        "graph_status": "grinding",
+        "error": None,
+        "escalation_decision": None,
+    }
+
+    branch_a_update = {"failed_subtask_ids": ["task-001"]}
+    branch_b_update = {"completed_subtask_ids": ["task-002"]}
+
+    # Apply each branch update through the union reducer
+    merged_failed = _union_ids(
+        base_state["failed_subtask_ids"],
+        branch_a_update["failed_subtask_ids"],
+    )
+    merged_completed = _union_ids(
+        base_state["completed_subtask_ids"],
+        branch_b_update["completed_subtask_ids"],
+    )
+
+    assert "task-001" in merged_failed
+    assert "task-002" in merged_completed
+
+
+def test_fanin_subtasks_both_failed_and_completed_in_list() -> None:
+    """Simulate two parallel branches updating subtasks with different statuses.
+
+    Branch A marks task-001 as failed.
+    Branch B marks task-002 as completed.
+
+    After fan-in merge, both subtasks are present with their correct statuses.
+    """
+    subtask_1_failed = SubTask(
+        id="task-001",
+        wiki_page="Page1",
+        title="Title",
+        description="Desc",
+        status="failed",
+        assigned_grinder=None,
+        branch_name=None,
+        pr_url=None,
+        pr_number=None,
+        attempt=0,
+        max_attempts=3,
+        error_log=["error"],
+        files_touched=[],
+        token_budget=50000,
+        tokens_used=0,
+        review_feedback=None,
+        code_skeleton=None,
+    )
+    subtask_2_completed = SubTask(
+        id="task-002",
+        wiki_page="Page2",
+        title="Title",
+        description="Desc",
+        status="merged",
+        assigned_grinder=None,
+        branch_name=None,
+        pr_url=None,
+        pr_number=None,
+        attempt=0,
+        max_attempts=3,
+        error_log=[],
+        files_touched=[],
+        token_budget=50000,
+        tokens_used=0,
+        review_feedback=None,
+        code_skeleton=None,
+    )
+
+    base_subtasks = [subtask_1_failed]
+    branch_b_subtasks = [subtask_2_completed]
+
+    merged = _merge_subtasks(base_subtasks, branch_b_subtasks)
+
+    assert len(merged) == 2
+    by_id = {s["id"]: s for s in merged}
+    assert by_id["task-001"]["status"] == "failed"
+    assert by_id["task-002"]["status"] == "merged"


### PR DESCRIPTION
## Summary

Fix fan-in state merge bug in FactoryState where failed status of earlier-finishing subtask was silently dropped when parallel grinder branches wrote state concurrently.

## Changes

- `orchestrator/factory/state.py`: Added `_union_ids` reducer and annotated `completed_subtask_ids` and `failed_subtask_ids` with union reducer
- `orchestrator/tests/test_state_reducers.py`: New test file verifying fan-in merge preserves both failed and completed subtask statuses

## Technical Details

When two parallel grinders finish at different times, LangGraph uses last-writer-wins for plain list fields. The fix adds custom reducers:

- `subtasks`: merge-by-ID reducer (already existed, last status wins per ID)
- `failed_subtask_ids`: union reducer - returns `list(set(left) | set(right))`
- `completed_subtask_ids`: union reducer - same pattern

## Test Verification

All 6 new reducer tests pass:
- `test_union_ids_merges_two_lists`
- `test_union_ids_handles_empty_lists`
- `test_merge_subtasks_last_status_wins_per_id`
- `test_merge_subtasks_preserves_distinct_ids`
- `test_fanin_preserves_failed_and_completed_subtask_ids`
- `test_fanin_subtasks_both_failed_and_completed_in_list`