### PR TITLE
[Factory] Improve E2B grinder bootstrap: orchestrator deps + pre-baked packages

### DIFF
--- a/orchestrator/e2b.Dockerfile
+++ b/orchestrator/e2b.Dockerfile
@@ -25,3 +25,11 @@ RUN pip install --no-cache-dir \
     pytest \
     pytest-asyncio \
     pytest-cov
+
+# Pre-bake meshwiki + orchestrator Python dependencies so runtime pip installs are fast.
+# Clone, install deps (non-editable), delete clone. The runtime `pip install -e .` will
+# skip downloading packages that are already installed.
+RUN git clone --depth 1 https://github.com/jhuhta/meshwiki.git /tmp/meshwiki-prebake \
+    && pip install --no-cache-dir "/tmp/meshwiki-prebake/src[dev]" \
+    && pip install --no-cache-dir "/tmp/meshwiki-prebake/orchestrator[dev]" \
+    && rm -rf /tmp/meshwiki-prebake

--- a/orchestrator/factory/agents/grinder_agent.py
+++ b/orchestrator/factory/agents/grinder_agent.py
@@ -633,6 +633,14 @@ async def grind_subtask_e2b(
             on_stderr=_on_stderr,
         )
 
+        # Install orchestrator deps (langgraph, anthropic, etc.)
+        await sbx.commands.run(
+            "cd /tmp/repo/orchestrator && pip install -e '.[dev]' -q --no-cache-dir",
+            timeout=0,
+            on_stdout=_on_stdout,
+            on_stderr=_on_stderr,
+        )
+
         # Write task file
         await sbx.files.write("/tmp/task.md", task_prompt)
 


### PR DESCRIPTION
## Summary
- Add orchestrator deps install step in `grinder_agent.py` after meshwiki dep install
- Pre-bake meshwiki + orchestrator Python dependencies in `e2b.Dockerfile` for faster runtime installs

## Changes
- `orchestrator/factory/agents/grinder_agent.py`: Added second `pip install -e '.[dev]'` step for orchestrator deps
- `orchestrator/e2b.Dockerfile`: Added pre-bake step that clones repo and installs both `src[dev]` and `orchestrator[dev]` dependencies

## Important
After merging this PR, the E2B template must be rebuilt:
```bash
cd orchestrator && e2b template build --name meshwiki-grinder
```

## Testing
- Test failure in `test_page_list_macro.py::TestPageListBasic::test_renders_all_pages` is pre-existing (verified on staging branch before these changes)