### PR TITLE
[Factory] Implement <<LastModified>> wiki macro

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -379,6 +379,66 @@ class RecentChangesExtension(Extension):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# LastModified macro
+# ─────────────────────────────────────────────────────────────────────────────
+
+LASTMODIFIED_PATTERN = re.compile(r"<<LastModified>>")
+
+
+class LastModifiedPreprocessor(Preprocessor):
+    """Preprocessor that replaces <<LastModified>> with relative time."""
+
+    def __init__(self, md: Markdown, modified: datetime | None):
+        super().__init__(md)
+        self.modified = modified
+
+    def run(self, lines: list[str]) -> list[str]:
+        text = "\n".join(lines)
+        if "<<LastModified>>" not in text:
+            return lines
+
+        code_block_re = re.compile(r"(```.*?```|~~~.*?~~~)", re.DOTALL)
+        code_blocks: list[str] = []
+
+        def stash_code(m: re.Match) -> str:
+            placeholder = f"\x00LMBLOCK{len(code_blocks)}\x00"
+            code_blocks.append(m.group(0))
+            return placeholder
+
+        text = code_block_re.sub(stash_code, text)
+
+        def replace_match(_m: re.Match) -> str:
+            if self.modified:
+                rel = _timeago(self.modified)
+                html = f'<span class="last-modified">Last modified {rel}</span>'
+            else:
+                html = '<span class="last-modified">—</span>'
+            return self.md.htmlStash.store(html)
+
+        text = LASTMODIFIED_PATTERN.sub(replace_match, text)
+
+        for i, block in enumerate(code_blocks):
+            text = text.replace(f"\x00LMBLOCK{i}\x00", block)
+
+        return text.split("\n")
+
+
+class LastModifiedExtension(Extension):
+    """Markdown extension for <<LastModified>> macro."""
+
+    def __init__(self, modified: datetime | None = None, **kwargs):
+        self.modified = modified
+        super().__init__(**kwargs)
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            LastModifiedPreprocessor(md, self.modified),
+            "lastmodified",
+            29,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # PageCount macro
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -1599,6 +1659,7 @@ def create_parser(
     recent_pages: list | None = None,
     page_contents: dict[str, str] | None = None,
     include_chain: list[str] | None = None,
+    page_modified: datetime | None = None,
 ) -> Markdown:
     """Create a Markdown parser with wiki link support.
 
@@ -1610,6 +1671,7 @@ def create_parser(
         recent_pages: List of Page objects for RecentChanges macro.
         page_contents: Dict mapping page names to raw content for Include macro.
         include_chain: List of page names in the current include chain (for circular detection).
+        page_modified: Last modified datetime of the page (for LastModified macro).
 
     Returns:
         Configured Markdown parser instance.
@@ -1643,6 +1705,7 @@ def create_parser(
                 include_chain=include_chain or [],
             ),  # <<Include(...)>>
             NewPageExtension(),  # <<NewPage(...)>>
+            LastModifiedExtension(modified=page_modified),  # <<LastModified>>
             CalloutExtension(),  # ```info / ```warning / ```tip / ```error / ```note
         ]
     )
@@ -1656,6 +1719,7 @@ def parse_wiki_content(
     recent_pages: list | None = None,
     page_contents: dict[str, str] | None = None,
     include_chain: list[str] | None = None,
+    page_modified: datetime | None = None,
 ) -> str:
     """Parse wiki content (Markdown + wiki links) to HTML.
 
@@ -1667,6 +1731,7 @@ def parse_wiki_content(
         recent_pages: List of Page objects for RecentChanges macro.
         page_contents: Dict mapping page names to raw content for Include macro.
         include_chain: List of page names in the current include chain (for circular detection).
+        page_modified: Last modified datetime of the page (for LastModified macro).
 
     Returns:
         HTML string.
@@ -1678,6 +1743,7 @@ def parse_wiki_content(
         recent_pages=recent_pages,
         page_contents=page_contents,
         include_chain=include_chain or [],
+        page_modified=page_modified,
     )
     return parser.convert(content)
 
@@ -1690,6 +1756,7 @@ def parse_wiki_content_with_toc(
     recent_pages: list | None = None,
     page_contents: dict[str, str] | None = None,
     include_chain: list[str] | None = None,
+    page_modified: datetime | None = None,
 ) -> tuple[str, str]:
     """Parse wiki content and return HTML with table of contents.
 
@@ -1701,6 +1768,7 @@ def parse_wiki_content_with_toc(
         recent_pages: List of Page objects for RecentChanges macro.
         page_contents: Dict mapping page names to raw content for Include macro.
         include_chain: List of page names in the current include chain (for circular detection).
+        page_modified: Last modified datetime of the page (for LastModified macro).
 
     Returns:
         Tuple of (html_content, toc_html).
@@ -1712,6 +1780,7 @@ def parse_wiki_content_with_toc(
         recent_pages=recent_pages,
         page_contents=page_contents,
         include_chain=include_chain or [],
+        page_modified=page_modified,
     )
     html = parser.convert(content)
     toc_html = getattr(parser, "toc", "")

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -467,6 +467,7 @@ async def view_page(request: Request, name: str):
         page_metadata=page_metadata,
         recent_pages=recent_pages,
         page_contents=page_contents,
+        page_modified=page.metadata.modified,
     )
 
     return templates.TemplateResponse(

--- a/src/tests/test_macros.py
+++ b/src/tests/test_macros.py
@@ -1,0 +1,154 @@
+"""Unit tests for the <<LastModified>> macro."""
+
+from datetime import datetime, timedelta, timezone
+
+import markdown
+import pytest
+
+from meshwiki.core.parser import LastModifiedExtension, parse_wiki_content
+
+
+def _render(content: str, modified: datetime | None) -> str:
+    """Render wiki content with LastModified macro."""
+    ext = LastModifiedExtension(modified=modified)
+    md = markdown.Markdown(extensions=[ext])
+    return md.convert(content)
+
+
+class TestLastModifiedBasic:
+    """Basic rendering tests."""
+
+    def test_last_modified_with_recent_datetime(self):
+        """<<LastModified>> with recent datetime renders relative time."""
+        dt = datetime.now(timezone.utc) - timedelta(minutes=30)
+        html = _render("<<LastModified>>", modified=dt)
+        assert '<span class="last-modified">' in html
+        assert "Last modified" in html
+        assert "30m ago" in html
+
+    def test_last_modified_with_hours_ago(self):
+        """<<LastModified>> with hours ago renders hours."""
+        dt = datetime.now(timezone.utc) - timedelta(hours=3)
+        html = _render("<<LastModified>>", modified=dt)
+        assert '<span class="last-modified">' in html
+        assert "Last modified" in html
+        assert "3h ago" in html
+
+    def test_last_modified_with_days_ago(self):
+        """<<LastModified>> with days ago renders days."""
+        dt = datetime.now(timezone.utc) - timedelta(days=2)
+        html = _render("<<LastModified>>", modified=dt)
+        assert '<span class="last-modified">' in html
+        assert "Last modified" in html
+        assert "2d ago" in html
+
+    def test_last_modified_with_old_date(self):
+        """<<LastModified>> with very old date renders date string."""
+        dt = datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        html = _render("<<LastModified>>", modified=dt)
+        assert '<span class="last-modified">' in html
+        assert "Last modified" in html
+        assert "2020-01-01" in html
+
+    def test_last_modified_with_just_now(self):
+        """<<LastModified>> with very recent time renders just now."""
+        dt = datetime.now(timezone.utc) - timedelta(seconds=30)
+        html = _render("<<LastModified>>", modified=dt)
+        assert '<span class="last-modified">' in html
+        assert "Last modified" in html
+        assert "just now" in html
+
+
+class TestLastModifiedNone:
+    """Tests for None modified datetime."""
+
+    def test_last_modified_none(self):
+        """<<LastModified>> with None renders em dash."""
+        html = _render("<<LastModified>>", modified=None)
+        assert '<span class="last-modified">—</span>' in html
+        assert "Last modified" not in html
+
+
+class TestLastModifiedNoMacro:
+    """Tests for content without the macro."""
+
+    def test_last_modified_no_macro(self):
+        """Content without <<LastModified>> is unaffected."""
+        html = _render("Hello world", modified=datetime.now(timezone.utc))
+        assert "last-modified" not in html
+        assert "Hello world" in html
+
+    def test_last_modified_no_macro_with_other_content(self):
+        """Content with other wiki syntax is unaffected."""
+        html = _render("# Hello\n\nSome content", modified=datetime.now(timezone.utc))
+        assert '<span class="last-modified">' not in html
+        assert "<h1>Hello</h1>" in html
+
+
+class TestLastModifiedEdgeCases:
+    """Edge case handling."""
+
+    def test_last_modified_in_text(self):
+        """<<LastModified>> within text is replaced correctly."""
+        dt = datetime.now(timezone.utc) - timedelta(hours=1)
+        html = _render("This page was <<LastModified>>.", modified=dt)
+        assert '<span class="last-modified">' in html
+        assert "This page was" in html
+        assert "." in html
+
+    def test_last_modified_naive_datetime(self):
+        """<<LastModified>> with naive datetime still works."""
+        dt = datetime.now() - timedelta(hours=1)
+        html = _render("<<LastModified>>", modified=dt)
+        assert '<span class="last-modified">' in html
+
+    def test_last_modified_not_replaced_in_code_block(self):
+        """<<LastModified>> inside code blocks is escaped, not rendered."""
+        content = "```\n<<LastModified>>\n```"
+        html = _render(content, modified=datetime.now(timezone.utc))
+        assert '<span class="last-modified">' not in html
+        assert "&lt;&lt;LastModified&gt;&gt;" in html
+
+    def test_last_modified_not_replaced_in_tilde_code_block(self):
+        """<<LastModified>> inside ~~~ code blocks is escaped."""
+        content = "~~~\n<<LastModified>>\n~~~"
+        html = _render(content, modified=datetime.now(timezone.utc))
+        assert '<span class="last-modified">' not in html
+
+
+class TestLastModifiedViaParseWikiContent:
+    """Test <<LastModified>> via parse_wiki_content function."""
+
+    def test_via_parse_wiki_content_with_datetime(self):
+        """<<LastModified>> works via parse_wiki_content."""
+        dt = datetime.now(timezone.utc) - timedelta(minutes=45)
+        html = parse_wiki_content("<<LastModified>>", page_modified=dt)
+        assert '<span class="last-modified">' in html
+        assert "45m ago" in html
+
+    def test_via_parse_wiki_content_with_none(self):
+        """<<LastModified>> with None works via parse_wiki_content."""
+        html = parse_wiki_content("<<LastModified>>", page_modified=None)
+        assert '<span class="last-modified">—</span>' in html
+
+
+class TestLastModifiedViaApi:
+    """Render <<LastModified>> through the real FastAPI route."""
+
+    @pytest.mark.asyncio
+    async def test_last_modified_renders_via_route(self, tmp_path):
+        import meshwiki.main
+
+        meshwiki.main.storage.base_path = tmp_path
+        await meshwiki.main.storage.save_page(
+            "LMMacroTest", "Modified: <<LastModified>>"
+        )
+
+        from httpx import ASGITransport, AsyncClient
+
+        transport = ASGITransport(app=meshwiki.main.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/page/LMMacroTest")
+
+        assert resp.status_code == 200
+        assert '<span class="last-modified">' in resp.text


### PR DESCRIPTION
## Summary
- Implement `<<LastModified>>` wiki macro that renders the current page's last-modified date as a relative time string
- Added `LastModifiedPreprocessor` and `LastModifiedExtension` classes in `parser.py` following the Pattern B (constructor injection) pattern
- Updated `create_parser`, `parse_wiki_content`, and `parse_wiki_content_with_toc` to accept `page_modified` parameter
- Wired up `page_modified=page.metadata.modified` in `main.py` route handler
- Added 15 unit tests covering basic rendering, None handling, edge cases, and API integration

## Testing
- All 15 new tests pass
- Existing tests unaffected (pre-existing failure in `test_page_list_macro.py` confirmed unrelated)