### PR TITLE
[Factory] Add macro escape syntax

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -15,6 +15,44 @@ from markdown.preprocessors import Preprocessor
 
 from meshwiki.core.graph import get_engine
 
+_ESCAPED_MACRO_RE = re.compile(r"\\<<([A-Za-z][^>]*)>>")
+
+
+class MacroEscapePreprocessor(Preprocessor):
+    def run(self, lines: list[str]) -> list[str]:
+        text = "\n".join(lines)
+
+        code_block_re = re.compile(r"(```.*?```|~~~.*?~~~)", re.DOTALL)
+        code_blocks: list[str] = []
+
+        def stash_code(m: re.Match) -> str:
+            placeholder = f"\x00ESCCODE{len(code_blocks)}\x00"
+            code_blocks.append(m.group(0))
+            return placeholder
+
+        text = code_block_re.sub(stash_code, text)
+
+        def _replace(m: re.Match) -> str:
+            literal = f"<<{m.group(1)}>>"
+            return f'<span class="macro-literal">{html_escape(literal)}</span>'
+
+        text = _ESCAPED_MACRO_RE.sub(_replace, text)
+
+        for i, block in enumerate(code_blocks):
+            text = text.replace(f"\x00ESCCODE{i}\x00", block)
+
+        return text.split("\n")
+
+
+class MacroEscapeExtension(Extension):
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            MacroEscapePreprocessor(md),
+            "macro_escape",
+            200,
+        )
+
+
 # Pattern for wiki links: [[PageName]] or [[PageName|Display Text]]
 WIKI_LINK_PATTERN = r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]"
 
@@ -1776,6 +1814,7 @@ def create_parser(
             # PyMdown extensions
             "pymdownx.tasklist",  # Task lists with checkboxes
             # Custom extensions
+            MacroEscapeExtension(),  # \<<Macro>> escape — must run first (priority 200)
             StrikethroughExtension(),  # ~~strikethrough~~
             WikiLinkExtension(page_exists=page_exists),  # [[WikiLinks]]
             MetaTableExtension(),  # <<MetaTable(...)>>

--- a/src/tests/test_parser.py
+++ b/src/tests/test_parser.py
@@ -344,3 +344,92 @@ modified: '2026-01-02'
 This is body text with five words.
 """
         assert word_count(content) == 7
+
+
+# ============================================================
+# Macro escape syntax
+# ============================================================
+
+
+class TestMacroEscape:
+    def test_escaped_pagelist_renders_literal(self):
+        html = parse_wiki_content("Use \\<<PageList>> to show pages.")
+        assert "macro-literal" in html
+        assert "&lt;&lt;PageList&gt;&gt;" in html or "<<PageList>>" in html
+
+    def test_escaped_taglist_renders_literal(self):
+        html = parse_wiki_content("Use \\<<TagList>> to show tags.")
+        assert "macro-literal" in html
+        assert "&lt;&lt;TagList&gt;&gt;" in html or "<<TagList>>" in html
+
+    def test_escaped_recentchanges_renders_literal(self):
+        html = parse_wiki_content("Use \\<<RecentChanges>> here.")
+        assert "macro-literal" in html
+
+    def test_escaped_lastmodified_renders_literal(self):
+        html = parse_wiki_content("Modified: \\<<LastModified>>")
+        assert "macro-literal" in html
+
+    def test_escaped_taskstatus_renders_literal(self):
+        html = parse_wiki_content("Status macro: \\<<TaskStatus>>")
+        assert "macro-literal" in html
+
+    def test_escaped_pagecount_renders_literal(self):
+        html = parse_wiki_content("Count: \\<<PageCount>>")
+        assert "macro-literal" in html
+
+    def test_escaped_backlinks_renders_literal(self):
+        html = parse_wiki_content("Links: \\<<BackLinks>>")
+        assert "macro-literal" in html
+
+    def test_escaped_includemacro_renders_literal(self):
+        html = parse_wiki_content("Include: \\<<Include(Page)>>")
+        assert "macro-literal" in html
+
+    def test_escaped_metatable_renders_literal(self):
+        html = parse_wiki_content("Meta: \\<<MetaTable()>>")
+        assert "macro-literal" in html
+
+    def test_escaped_newpage_renders_literal(self):
+        html = parse_wiki_content("New: \\<<NewPage>>")
+        assert "macro-literal" in html
+
+    def test_unescaped_pagelist_not_expanded_without_engine(self):
+        html = parse_wiki_content("<<PageList>>")
+        assert "macro-literal" not in html
+        assert "&lt;&lt;PageList&gt;&gt;" not in html
+
+    def test_unescaped_taglist_renders(self):
+        html = parse_wiki_content("<<TagList>>")
+        assert "macro-literal" not in html
+
+    def test_double_backslash_escapes_backslash(self):
+        html = parse_wiki_content("A literal backslash: \\\\<<PageList>>")
+        assert "macro-literal" in html
+        assert "\\" in html
+
+    def test_escaped_macro_in_code_block_not_expanded(self):
+        content = "```\n\\<<PageList>>\n```"
+        html = parse_wiki_content(content)
+        assert "macro-literal" not in html
+
+    def test_escaped_macro_in_tilde_code_not_expanded(self):
+        content = "~~~\n\\<<PageList>>\n~~~"
+        html = parse_wiki_content(content)
+        assert "macro-literal" not in html
+
+    def test_multiple_escaped_macros(self):
+        html = parse_wiki_content("\\<<PageList>> and \\<<TagList>>")
+        assert html.count("macro-literal") == 2
+
+    def test_mixed_escaped_and_unescaped(self):
+        html = parse_wiki_content("\\<<PageList>> or <<PageList>>")
+        assert html.count("macro-literal") == 1
+
+    def test_escaped_macro_with_args(self):
+        html = parse_wiki_content("\\<<PageList(tag=test)>>")
+        assert "macro-literal" in html
+
+    def test_escaped_epicstatus_renders_literal(self):
+        html = parse_wiki_content("\\<<EpicStatus>>")
+        assert "macro-literal" in html


### PR DESCRIPTION
## Summary
- Add `\<<MacroName>>` escape syntax to prevent macro expansion
- `\<<PageList>>` renders as literal `<<PageList>>` (not expanded)
- `<<PageList>>` without backslash continues to expand normally
- Works for all macros: PageList, RecentChanges, LastModified, TagList, TaskStatus, etc.
- Double backslash `\\<<PageList>>` renders as `\<<PageList>>` (escaped backslash + literal)
- Escape is handled by a preprocessor at priority 200 (runs before all macro preprocessors)

## Changes
- `src/meshwiki/core/parser.py`: Added `MacroEscapePreprocessor` and `MacroEscapeExtension`
- `src/tests/test_parser.py`: Added 18 tests for macro escape functionality

## Testing
- All 546 tests pass (excluding pre-existing failing test in test_page_list_macro.py)
- Lint checks pass