### PR TITLE
[Factory] Shared httpx.AsyncClient for MeshWikiClient and GitHubClient

### DIFF
--- a/orchestrator/factory/agents/pm_agent.py
+++ b/orchestrator/factory/agents/pm_agent.py
@@ -343,7 +343,10 @@ async def _messages_create_with_retry(
                     for b in content
                     if hasattr(b, "type") and b.type == "tool_use"
                 ]
-                oai_msg: dict[str, Any] = {"role": "assistant", "content": " ".join(text_parts) or None}
+                oai_msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "content": " ".join(text_parts) or None,
+                }
                 if tool_calls:
                     oai_msg["tool_calls"] = tool_calls
                 oai_messages.append(oai_msg)
@@ -354,11 +357,13 @@ async def _messages_create_with_retry(
             if isinstance(content, list):
                 for block in content:
                     if isinstance(block, dict) and block.get("type") == "tool_result":
-                        oai_messages.append({
-                            "role": "tool",
-                            "tool_call_id": block["tool_use_id"],
-                            "content": str(block.get("content", "")),
-                        })
+                        oai_messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": block["tool_use_id"],
+                                "content": str(block.get("content", "")),
+                            }
+                        )
                     else:
                         oai_messages.append({"role": "user", "content": str(block)})
             else:
@@ -616,7 +621,7 @@ async def review_with_pm(
         "(staging), not relative to main. Changes that were already on staging will NOT "
         "appear in the diff even if they are part of the full implementation. Before "
         "requesting changes for a missing feature, use `github_read_file` with "
-        f"`ref: \"{branch_name}\"` to read the actual current file and verify whether "
+        f'`ref: "{branch_name}"` to read the actual current file and verify whether '
         "the feature is already present.\n\n"
         "Please review this PR. "
         "Use `pm_approve_pr` if the implementation meets all acceptance criteria, "

--- a/orchestrator/factory/config.py
+++ b/orchestrator/factory/config.py
@@ -32,11 +32,21 @@ class Settings(BaseSettings):
     grinder_model: str = "MiniMax-M2.7"  # FACTORY_GRINDER_MODEL
     checkpoint_db: str = "/data/checkpoints.db"  # FACTORY_CHECKPOINT_DB
     pr_base_branch: str = "main"  # FACTORY_PR_BASE_BRANCH — branch grinders target
-    auto_merge: bool = False  # FACTORY_AUTO_MERGE — merge PRs after PM approval, skip human review
-    pm_decompose_model: str = "claude-sonnet-4-6"  # FACTORY_PM_DECOMPOSE_MODEL — task decomposition
-    pm_review_model: str = "claude-sonnet-4-6"  # FACTORY_PM_REVIEW_MODEL — full review model
-    pm_triage_model: str = "claude-haiku-4-5-20251001"  # FACTORY_PM_TRIAGE_MODEL — fast triage; empty = skip triage
-    pm_review_max_diff_lines: int = 500  # FACTORY_PM_REVIEW_MAX_DIFF_LINES — truncate diff beyond this
+    auto_merge: bool = (
+        False  # FACTORY_AUTO_MERGE — merge PRs after PM approval, skip human review
+    )
+    pm_decompose_model: str = (
+        "claude-sonnet-4-6"  # FACTORY_PM_DECOMPOSE_MODEL — task decomposition
+    )
+    pm_review_model: str = (
+        "claude-sonnet-4-6"  # FACTORY_PM_REVIEW_MODEL — full review model
+    )
+    pm_triage_model: str = (
+        "claude-haiku-4-5-20251001"  # FACTORY_PM_TRIAGE_MODEL — fast triage; empty = skip triage
+    )
+    pm_review_max_diff_lines: int = (
+        500  # FACTORY_PM_REVIEW_MAX_DIFF_LINES — truncate diff beyond this
+    )
 
     model_config = SettingsConfigDict(env_prefix="FACTORY_")
 

--- a/orchestrator/factory/graph.py
+++ b/orchestrator/factory/graph.py
@@ -52,9 +52,7 @@ def route_after_grinding(state: FactoryState) -> str:
     failed = [s for s in state["subtasks"] if s["status"] == "failed"]
     succeeded = [s for s in state["subtasks"] if s["status"] == "review"]
     pending = [
-        s
-        for s in state["subtasks"]
-        if s["status"] in ("pending", "changes_requested")
+        s for s in state["subtasks"] if s["status"] in ("pending", "changes_requested")
     ]
     if not failed:
         if pending:
@@ -69,6 +67,7 @@ def route_after_grinding(state: FactoryState) -> str:
 def route_after_pm_review(state: FactoryState) -> str:
     """Route after PM reviews grinder-produced code."""
     from .config import get_settings
+
     needs_rework = [s for s in state["subtasks"] if s["status"] == "changes_requested"]
     exhausted = [s for s in needs_rework if s["attempt"] >= s["max_attempts"]]
     if exhausted:

--- a/orchestrator/factory/integrations/github_client.py
+++ b/orchestrator/factory/integrations/github_client.py
@@ -28,15 +28,30 @@ class GitHubClient:
         settings = get_settings()
         self._token = token or settings.github_token
         self._repo = repo or settings.github_repo
+        self._client = httpx.AsyncClient(
+            base_url=_BASE_URL,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=30.0,
+        )
 
     def _headers(self) -> dict[str, str]:
-        headers: dict[str, str] = {
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
+        headers: dict[str, str] = {}
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"
         return headers
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "GitHubClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close()
 
     async def get_pr(self, pr_number: int) -> dict:
         """Fetch full pull request metadata.
@@ -50,11 +65,10 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers())
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}"
+        resp = await self._client.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
 
     async def get_pr_diff(self, pr_number: int) -> str:
         """Fetch the unified diff for a pull request.
@@ -68,12 +82,11 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}"
+        url = f"/repos/{self._repo}/pulls/{pr_number}"
         headers = {**self._headers(), "Accept": "application/vnd.github.v3.diff"}
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=headers)
-            resp.raise_for_status()
-            return resp.text
+        resp = await self._client.get(url, headers=headers)
+        resp.raise_for_status()
+        return resp.text
 
     async def create_pr_comment(self, pr_number: int, body: str) -> dict:
         """Post an issue comment on a pull request.
@@ -88,15 +101,14 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/issues/{pr_number}/comments"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"body": body},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/issues/{pr_number}/comments"
+        resp = await self._client.post(
+            url,
+            headers=self._headers(),
+            json={"body": body},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     async def request_changes(self, pr_number: int, body: str) -> dict:
         """Submit a 'REQUEST_CHANGES' review on a pull request.
@@ -111,15 +123,14 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}/reviews"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"event": "REQUEST_CHANGES", "body": body},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}/reviews"
+        resp = await self._client.post(
+            url,
+            headers=self._headers(),
+            json={"event": "REQUEST_CHANGES", "body": body},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     async def approve_pr(self, pr_number: int, body: str = "") -> dict:
         """Submit an 'APPROVE' review on a pull request.
@@ -134,17 +145,21 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}/reviews"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"event": "APPROVE", "body": body},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}/reviews"
+        resp = await self._client.post(
+            url,
+            headers=self._headers(),
+            json={"event": "APPROVE", "body": body},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
-    async def merge_pr(self, pr_number: int, commit_title: str = "", merge_method: str = "squash") -> dict:
+    async def merge_pr(
+        self,
+        pr_number: int,
+        commit_title: str = "",
+        merge_method: str = "squash",
+    ) -> dict:
         """Merge a pull request via the GitHub API.
 
         Args:
@@ -158,14 +173,13 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}/merge"
+        url = f"/repos/{self._repo}/pulls/{pr_number}/merge"
         body: dict = {"merge_method": merge_method}
         if commit_title:
             body["commit_title"] = commit_title
-        async with httpx.AsyncClient() as client:
-            resp = await client.put(url, headers=self._headers(), json=body)
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.put(url, headers=self._headers(), json=body)
+        resp.raise_for_status()
+        return resp.json()
 
     async def get_file_content(self, path: str, ref: str = "staging") -> str:
         """Fetch raw content of a file from the repository.
@@ -183,11 +197,10 @@ class GitHubClient:
         """
         import base64
 
-        url = f"{_BASE_URL}/repos/{self._repo}/contents/{path}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers(), params={"ref": ref})
-            resp.raise_for_status()
-            data = resp.json()
+        url = f"/repos/{self._repo}/contents/{path}"
+        resp = await self._client.get(url, headers=self._headers(), params={"ref": ref})
+        resp.raise_for_status()
+        data = resp.json()
         if data.get("type") != "file":
             raise ValueError(f"Not a file: {path!r} (type={data.get('type')})")
         return base64.b64decode(data["content"]).decode("utf-8", errors="replace")
@@ -204,15 +217,14 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.patch(
-                url,
-                headers=self._headers(),
-                json={"state": "closed"},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}"
+        resp = await self._client.patch(
+            url,
+            headers=self._headers(),
+            json={"state": "closed"},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
 
 def _extract_pr_number(pr_url: str) -> int | None:

--- a/orchestrator/factory/integrations/meshwiki_client.py
+++ b/orchestrator/factory/integrations/meshwiki_client.py
@@ -1,7 +1,15 @@
 """Async HTTP client wrapping the MeshWiki JSON API."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
+
+import httpx
+
+from ..config import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 def _patch_frontmatter(content: str, updates: dict[str, Any]) -> str:
@@ -17,7 +25,7 @@ def _patch_frontmatter(content: str, updates: dict[str, Any]) -> str:
     if close == -1:
         return content
     front_lines = content[4:close].split("\n")
-    body = content[close + 5:]
+    body = content[close + 5 :]
 
     updated_keys: set[str] = set()
     new_front: list[str] = []
@@ -36,12 +44,6 @@ def _patch_frontmatter(content: str, updates: dict[str, Any]) -> str:
 
     return "---\n" + "\n".join(new_front) + "\n---\n" + body
 
-import httpx
-
-from ..config import get_settings
-
-logger = logging.getLogger(__name__)
-
 
 class MeshWikiClient:
     """Async client for the MeshWiki JSON API (``/api/v1/``)."""
@@ -50,12 +52,27 @@ class MeshWikiClient:
         settings = get_settings()
         self._base_url = (base_url or settings.meshwiki_url).rstrip("/")
         self._api_key = api_key or settings.meshwiki_api_key
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=self._headers(),
+            timeout=30.0,
+        )
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
         return headers
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "MeshWikiClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close()
 
     async def get_page(self, name: str) -> dict | None:
         """
@@ -65,12 +82,11 @@ class MeshWikiClient:
         the page does not exist.
         """
         url = f"{self._base_url}/api/v1/pages/{name}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers())
-            if resp.status_code == 404:
-                return None
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.get(url)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
 
     async def create_page(self, name: str, content: str) -> dict:
         """
@@ -80,14 +96,12 @@ class MeshWikiClient:
         Returns the saved page dict.
         """
         url = f"{self._base_url}/api/v1/pages/{name}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.put(
-                url,
-                headers=self._headers(),
-                json={"name": name, "content": content},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.put(
+            url,
+            json={"name": name, "content": content},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     async def transition_task(
         self,
@@ -110,14 +124,9 @@ class MeshWikiClient:
         payload: dict[str, Any] = {"status": status}
         if extra_fields:
             payload.update(extra_fields)
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json=payload,
-            )
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.post(url, json=payload)
+        resp.raise_for_status()
+        return resp.json()
 
     async def relay_terminal(self, task_name: str, data: str) -> None:
         """Relay a raw PTY / stdout chunk to the MeshWiki live terminal stream.
@@ -131,8 +140,7 @@ class MeshWikiClient:
         """
         url = f"{self._base_url}/api/v1/tasks/{task_name}/terminal"
         try:
-            async with httpx.AsyncClient() as client:
-                await client.post(url, headers=self._headers(), json={"data": data})
+            await self._client.post(url, json={"data": data})
         except Exception as exc:
             logger.debug("terminal relay failed (non-critical): %s", exc)
 
@@ -146,10 +154,9 @@ class MeshWikiClient:
         params: dict[str, str] = {}
         if status is not None:
             params["status"] = status
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers(), params=params)
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()
 
     async def rename_page(self, old_name: str, new_name: str) -> None:
         """Move a wiki page to a new name/location.
@@ -159,13 +166,11 @@ class MeshWikiClient:
             new_name: New page name (may include new path segments).
         """
         url = f"{self._base_url}/api/v1/pages/{old_name}/rename"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"new_name": new_name},
-            )
-            resp.raise_for_status()
+        resp = await self._client.post(
+            url,
+            json={"new_name": new_name},
+        )
+        resp.raise_for_status()
 
     async def append_to_page(
         self,
@@ -177,7 +182,7 @@ class MeshWikiClient:
         Append content_to_append to the body of the named wiki page.
 
         Gets the current page content, optionally patches frontmatter fields,
-        strips trailing whitespace, appends "\\n\\n" + content_to_append, then
+        strips trailing whitespace, appends "\n\n" + content_to_append, then
         PUTs the updated content back in a single round-trip.
         """
         page = await self.get_page(page_name)

--- a/orchestrator/factory/main.py
+++ b/orchestrator/factory/main.py
@@ -12,5 +12,7 @@ if __name__ == "__main__":
     # Configure root logger so factory.* loggers are visible.
     # Uvicorn only configures its own loggers; without this, application
     # INFO messages are silently dropped by the root logger's WARNING default.
-    logging.basicConfig(level=s.log_level.upper(), format="%(levelname)s:     %(name)s - %(message)s")
+    logging.basicConfig(
+        level=s.log_level.upper(), format="%(levelname)s:     %(name)s - %(message)s"
+    )
     uvicorn.run(app, host=s.host, port=s.port, log_level=s.log_level)

--- a/orchestrator/factory/nodes/decompose.py
+++ b/orchestrator/factory/nodes/decompose.py
@@ -99,59 +99,58 @@ async def decompose_node(state: FactoryState) -> dict:
         "decompose: decomposing task %s", state.get("task_wiki_page", "<unknown>")
     )
 
-    meshwiki_client = MeshWikiClient()
-    # github_client is not needed for decomposition
-    github_client = None
+    async with MeshWikiClient() as meshwiki_client:
+        subtasks = await decompose_with_pm(state, meshwiki_client, None)
 
-    subtasks = await decompose_with_pm(state, meshwiki_client, github_client)
+        parent_task = state.get("task_wiki_page", "")
 
-    parent_task = state.get("task_wiki_page", "")
-
-    # Guard: reject any subtask whose wiki_page is more than one level below
-    # the parent task — the PM must not create nested subtasks.
-    valid_subtasks = []
-    for subtask in subtasks:
-        page = subtask["wiki_page"]
-        expected_prefix = parent_task + "/"
-        relative = page[len(expected_prefix):] if page.startswith(expected_prefix) else page
-        if "/" in relative:
-            logger.error(
-                "decompose: rejecting nested subtask %s (parent=%s) — "
-                "subtask wiki_page must be a direct child of the parent task",
-                page,
-                parent_task,
+        valid_subtasks = []
+        for subtask in subtasks:
+            page = subtask["wiki_page"]
+            expected_prefix = parent_task + "/"
+            relative = (
+                page[len(expected_prefix) :]
+                if page.startswith(expected_prefix)
+                else page
             )
-            continue
-        valid_subtasks.append(subtask)
+            if "/" in relative:
+                logger.error(
+                    "decompose: rejecting nested subtask %s (parent=%s) — "
+                    "subtask wiki_page must be a direct child of the parent task",
+                    page,
+                    parent_task,
+                )
+                continue
+            valid_subtasks.append(subtask)
 
-    if len(valid_subtasks) != len(subtasks):
-        logger.warning(
-            "decompose: dropped %d nested subtask(s) out of %d",
-            len(subtasks) - len(valid_subtasks),
-            len(subtasks),
-        )
-    subtasks = valid_subtasks
+        if len(valid_subtasks) != len(subtasks):
+            logger.warning(
+                "decompose: dropped %d nested subtask(s) out of %d",
+                len(subtasks) - len(valid_subtasks),
+                len(subtasks),
+            )
+        subtasks = valid_subtasks
 
-    for subtask in subtasks:
-        page_content = _build_subtask_page(subtask, parent_task)
+        for subtask in subtasks:
+            page_content = _build_subtask_page(subtask, parent_task)
+            try:
+                await meshwiki_client.create_page(subtask["wiki_page"], page_content)
+                logger.info("decompose: created wiki page %s", subtask["wiki_page"])
+            except Exception as exc:
+                logger.error(
+                    "decompose: failed to create wiki page %s: %s",
+                    subtask["wiki_page"],
+                    exc,
+                )
+
         try:
-            await meshwiki_client.create_page(subtask["wiki_page"], page_content)
-            logger.info("decompose: created wiki page %s", subtask["wiki_page"])
+            await meshwiki_client.transition_task(parent_task, "decomposed")
+            logger.info(
+                "decompose: transitioned parent task %s to decomposed", parent_task
+            )
         except Exception as exc:
             logger.error(
-                "decompose: failed to create wiki page %s: %s",
-                subtask["wiki_page"],
-                exc,
+                "decompose: failed to transition parent task %s: %s", parent_task, exc
             )
-
-        # Page is created with status: planned already — no transition needed.
-
-    try:
-        await meshwiki_client.transition_task(parent_task, "decomposed")
-        logger.info("decompose: transitioned parent task %s to decomposed", parent_task)
-    except Exception as exc:
-        logger.error(
-            "decompose: failed to transition parent task %s: %s", parent_task, exc
-        )
 
     return {"subtasks": subtasks, "graph_status": "dispatching"}

--- a/orchestrator/factory/nodes/escalate.py
+++ b/orchestrator/factory/nodes/escalate.py
@@ -31,57 +31,55 @@ async def escalate_node(state: FactoryState) -> dict:
         Partial state update with updated ``subtasks``, ``graph_status``, and
         ``escalation_decision``.
     """
-    client = MeshWikiClient()
+    async with MeshWikiClient() as client:
+        failed_ids = state.get("failed_subtask_ids", [])
+        failed_subtasks = [s for s in state["subtasks"] if s["id"] in failed_ids]
 
-    failed_ids = state.get("failed_subtask_ids", [])
-    failed_subtasks = [s for s in state["subtasks"] if s["id"] in failed_ids]
+        logger.warning(
+            "escalate: escalating task %s (failed subtasks: %s)",
+            state.get("task_wiki_page", "<unknown>"),
+            failed_ids,
+        )
 
-    logger.warning(
-        "escalate: escalating task %s (failed subtasks: %s)",
-        state.get("task_wiki_page", "<unknown>"),
-        failed_ids,
-    )
+        retriable = [s for s in failed_subtasks if s["attempt"] < s["max_attempts"] - 1]
 
-    # Check which failed subtasks still have retries remaining
-    retriable = [s for s in failed_subtasks if s["attempt"] < s["max_attempts"] - 1]
-
-    # Append escalation note to the task wiki page
-    try:
-        page = await client.get_page(state["task_wiki_page"])
-        if page:
-            content = page.get("content", "")
-            note = f"\n\n## Escalation\n\nFailed subtasks: {', '.join(failed_ids)}\n"
-            if retriable:
-                note += f"Retrying: {', '.join(s['id'] for s in retriable)}\n"
-            await client.create_page(state["task_wiki_page"], content + note)
-    except Exception as exc:
-        logger.error("escalate: failed to update task page: %s", exc)
-
-    # Transition retriable subtask wiki pages back to in_progress so that
-    # grind_node can later transition them to review (failed->review is invalid).
-    for s in retriable:
         try:
-            await client.transition_task(s["wiki_page"], "in_progress")
-            logger.info("escalate: transitioned %s back to in_progress for retry", s["id"])
+            page = await client.get_page(state["task_wiki_page"])
+            if page:
+                content = page.get("content", "")
+                note = (
+                    f"\n\n## Escalation\n\nFailed subtasks: {', '.join(failed_ids)}\n"
+                )
+                if retriable:
+                    note += f"Retrying: {', '.join(s['id'] for s in retriable)}\n"
+                await client.create_page(state["task_wiki_page"], content + note)
         except Exception as exc:
-            logger.warning(
-                "escalate: could not transition %s to in_progress: %s", s["id"], exc
-            )
+            logger.error("escalate: failed to update task page: %s", exc)
 
-    # Increment attempt count on retriable failed subtasks and reset status
-    retriable_ids = {s["id"] for s in retriable}
-    subtasks = []
-    for s in state["subtasks"]:
-        if s["id"] in retriable_ids:
-            subtasks.append({**s, "attempt": s["attempt"] + 1, "status": "pending"})
-        else:
-            subtasks.append(s)
+        for s in retriable:
+            try:
+                await client.transition_task(s["wiki_page"], "in_progress")
+                logger.info(
+                    "escalate: transitioned %s back to in_progress for retry", s["id"]
+                )
+            except Exception as exc:
+                logger.warning(
+                    "escalate: could not transition %s to in_progress: %s", s["id"], exc
+                )
 
-    decision = "retry" if retriable else "abandon"
-    logger.info("escalate: decision=%s", decision)
+        retriable_ids = {s["id"] for s in retriable}
+        subtasks = []
+        for s in state["subtasks"]:
+            if s["id"] in retriable_ids:
+                subtasks.append({**s, "attempt": s["attempt"] + 1, "status": "pending"})
+            else:
+                subtasks.append(s)
 
-    return {
-        "subtasks": subtasks,
-        "graph_status": "escalated",
-        "escalation_decision": decision,
-    }
+        decision = "retry" if retriable else "abandon"
+        logger.info("escalate: decision=%s", decision)
+
+        return {
+            "subtasks": subtasks,
+            "graph_status": "escalated",
+            "escalation_decision": decision,
+        }

--- a/orchestrator/factory/nodes/finalize.py
+++ b/orchestrator/factory/nodes/finalize.py
@@ -20,27 +20,26 @@ async def finalize_node(state: FactoryState) -> dict:
     Returns:
         Partial state update setting ``graph_status`` to ``"completed"``.
     """
-    client = MeshWikiClient()
-
-    logger.info(
-        "finalize: completing task %s (cost: $%.4f)",
-        state.get("task_wiki_page", "<unknown>"),
-        state.get("cost_usd", 0.0),
-    )
-
-    task_page = state["task_wiki_page"]
-
-    try:
-        await client.transition_task(
-            task_page,
-            "done",
-            extra_fields={"cost_usd": str(round(state.get("cost_usd", 0), 4))},
-        )
-    except Exception as exc:
-        logger.error(
-            "finalize: failed to transition %s to done: %s",
-            task_page,
-            exc,
+    async with MeshWikiClient() as client:
+        logger.info(
+            "finalize: completing task %s (cost: $%.4f)",
+            state.get("task_wiki_page", "<unknown>"),
+            state.get("cost_usd", 0.0),
         )
 
-    return {"graph_status": "completed"}
+        task_page = state["task_wiki_page"]
+
+        try:
+            await client.transition_task(
+                task_page,
+                "done",
+                extra_fields={"cost_usd": str(round(state.get("cost_usd", 0), 4))},
+            )
+        except Exception as exc:
+            logger.error(
+                "finalize: failed to transition %s to done: %s",
+                task_page,
+                exc,
+            )
+
+        return {"graph_status": "completed"}

--- a/orchestrator/factory/nodes/grind.py
+++ b/orchestrator/factory/nodes/grind.py
@@ -34,63 +34,61 @@ async def grind_node(state: FactoryState) -> dict:
         logger.error("grind_node: subtask %r not found in state", subtask_id)
         return {}
 
-    # Guard: rework with no feedback wastes a full sandbox run.
-    # Fail fast so escalate_node can handle it rather than grinding blindly.
-    if subtask.get("attempt", 0) > 0 and not subtask.get("review_feedback"):
-        logger.warning(
-            "grind_node: subtask %s is a rework (attempt %d) but review_feedback is empty — failing fast",
+    async with MeshWikiClient() as meshwiki_client:
+        if subtask.get("attempt", 0) > 0 and not subtask.get("review_feedback"):
+            logger.warning(
+                "grind_node: subtask %s is a rework (attempt %d) but review_feedback is empty — failing fast",
+                subtask_id,
+                subtask.get("attempt", 0),
+            )
+            error_log = list(subtask.get("error_log") or []) + [
+                "PM requested changes but provided no feedback — cannot rework"
+            ]
+            updated = {**subtask, "status": "failed", "error_log": error_log}
+            try:
+                await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
+            except Exception as exc:
+                logger.error(
+                    "grind_node: failed to transition %s to failed: %s",
+                    subtask["wiki_page"],
+                    exc,
+                )
+            subtasks = [
+                updated if s["id"] == subtask_id else s for s in state["subtasks"]
+            ]
+            return {"subtasks": subtasks}
+
+        logger.info(
+            "grind_node: running grinder for subtask %s (task %s)",
             subtask_id,
-            subtask.get("attempt", 0),
+            state.get("task_wiki_page", "<unknown>"),
         )
-        error_log = list(subtask.get("error_log") or []) + [
-            "PM requested changes but provided no feedback — cannot rework"
-        ]
-        updated = {**subtask, "status": "failed", "error_log": error_log}
-        meshwiki_client = MeshWikiClient()
+
+        updated = await grind_subtask(state, subtask, meshwiki_client)
+
+        final_status = updated.get("status", "failed")
+        extra_fields: dict = {}
+        if updated.get("pr_url"):
+            extra_fields["pr_url"] = updated["pr_url"]
+        if updated.get("branch_name"):
+            extra_fields["branch"] = updated["branch_name"]
         try:
-            await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
+            await meshwiki_client.transition_task(
+                updated["wiki_page"], final_status, extra_fields or None
+            )
+            logger.info(
+                "grind_node: transitioned %s to %s (pr=%s)",
+                updated["wiki_page"],
+                final_status,
+                updated.get("pr_url"),
+            )
         except Exception as exc:
             logger.error(
-                "grind_node: failed to transition %s to failed: %s",
-                subtask["wiki_page"],
+                "grind_node: failed to transition %s to %s: %s",
+                updated["wiki_page"],
+                final_status,
                 exc,
             )
+
         subtasks = [updated if s["id"] == subtask_id else s for s in state["subtasks"]]
         return {"subtasks": subtasks}
-
-    logger.info(
-        "grind_node: running grinder for subtask %s (task %s)",
-        subtask_id,
-        state.get("task_wiki_page", "<unknown>"),
-    )
-
-    meshwiki_client = MeshWikiClient()
-    updated = await grind_subtask(state, subtask, meshwiki_client)
-
-    # Transition the wiki task page to reflect the grinder outcome
-    final_status = updated.get("status", "failed")
-    extra_fields: dict = {}
-    if updated.get("pr_url"):
-        extra_fields["pr_url"] = updated["pr_url"]
-    if updated.get("branch_name"):
-        extra_fields["branch"] = updated["branch_name"]
-    try:
-        await meshwiki_client.transition_task(
-            updated["wiki_page"], final_status, extra_fields or None
-        )
-        logger.info(
-            "grind_node: transitioned %s to %s (pr=%s)",
-            updated["wiki_page"],
-            final_status,
-            updated.get("pr_url"),
-        )
-    except Exception as exc:
-        logger.error(
-            "grind_node: failed to transition %s to %s: %s",
-            updated["wiki_page"],
-            final_status,
-            exc,
-        )
-
-    subtasks = [updated if s["id"] == subtask_id else s for s in state["subtasks"]]
-    return {"subtasks": subtasks}

--- a/orchestrator/factory/nodes/merge_check.py
+++ b/orchestrator/factory/nodes/merge_check.py
@@ -36,58 +36,57 @@ async def merge_check_node(state: FactoryState) -> dict:
         state.get("task_wiki_page", "<unknown>"),
     )
 
-    github_client = GitHubClient()
-    subtasks = list(state["subtasks"])
+    async with GitHubClient() as github_client:
+        subtasks = list(state["subtasks"])
 
-    for i, subtask in enumerate(subtasks):
-        if subtask["status"] != "review":
-            continue
+        for i, subtask in enumerate(subtasks):
+            if subtask["status"] != "review":
+                continue
 
-        pr_number: int | None = subtask.get("pr_number")
+            pr_number: int | None = subtask.get("pr_number")
 
-        # Fall back to extracting from pr_url if pr_number is not set
-        if pr_number is None:
-            pr_url = subtask.get("pr_url")
-            if pr_url:
-                pr_number = _extract_pr_number(pr_url)
+            if pr_number is None:
+                pr_url = subtask.get("pr_url")
+                if pr_url:
+                    pr_number = _extract_pr_number(pr_url)
 
-        if pr_number is None:
-            logger.warning(
-                "merge_check: subtask %s in 'review' has no pr_number or pr_url — skipping",
-                subtask["id"],
-            )
-            continue
+            if pr_number is None:
+                logger.warning(
+                    "merge_check: subtask %s in 'review' has no pr_number or pr_url — skipping",
+                    subtask["id"],
+                )
+                continue
 
-        try:
-            pr = await github_client.get_pr(pr_number)
-        except httpx.HTTPStatusError as exc:
-            logger.error(
-                "merge_check: failed to fetch PR #%s for subtask %s: %s",
-                pr_number,
-                subtask["id"],
-                exc,
-            )
-            continue
+            try:
+                pr = await github_client.get_pr(pr_number)
+            except httpx.HTTPStatusError as exc:
+                logger.error(
+                    "merge_check: failed to fetch PR #%s for subtask %s: %s",
+                    pr_number,
+                    subtask["id"],
+                    exc,
+                )
+                continue
 
-        if pr.get("merged"):
-            logger.info(
-                "merge_check: PR #%s is merged for subtask %s",
-                pr_number,
-                subtask["id"],
-            )
-            subtasks[i] = {**subtask, "status": "merged"}
-        elif pr.get("state") == "closed":
-            logger.info(
-                "merge_check: PR #%s is closed (not merged) for subtask %s — marking failed",
-                pr_number,
-                subtask["id"],
-            )
-            subtasks[i] = {**subtask, "status": "failed"}
-        else:
-            logger.debug(
-                "merge_check: PR #%s is still open for subtask %s",
-                pr_number,
-                subtask["id"],
-            )
+            if pr.get("merged"):
+                logger.info(
+                    "merge_check: PR #%s is merged for subtask %s",
+                    pr_number,
+                    subtask["id"],
+                )
+                subtasks[i] = {**subtask, "status": "merged"}
+            elif pr.get("state") == "closed":
+                logger.info(
+                    "merge_check: PR #%s is closed (not merged) for subtask %s — marking failed",
+                    pr_number,
+                    subtask["id"],
+                )
+                subtasks[i] = {**subtask, "status": "failed"}
+            else:
+                logger.debug(
+                    "merge_check: PR #%s is still open for subtask %s",
+                    pr_number,
+                    subtask["id"],
+                )
 
-    return {"subtasks": subtasks}
+        return {"subtasks": subtasks}

--- a/orchestrator/factory/nodes/pm_review.py
+++ b/orchestrator/factory/nodes/pm_review.py
@@ -31,133 +31,133 @@ async def pm_review_node(state: FactoryState) -> dict:
         state.get("task_wiki_page", "<unknown>"),
     )
 
-    meshwiki_client = MeshWikiClient()
-    github_client = GitHubClient()
+    async with MeshWikiClient() as meshwiki_client, GitHubClient() as github_client:
+        subtasks: list[SubTask] = list(state.get("subtasks", []))
+        review_subtasks = [s for s in subtasks if s["status"] == "review"]
 
-    subtasks: list[SubTask] = list(state.get("subtasks", []))
-    review_subtasks = [s for s in subtasks if s["status"] == "review"]
+        logger.info("pm_review: %d subtask(s) in review status", len(review_subtasks))
 
-    logger.info("pm_review: %d subtask(s) in review status", len(review_subtasks))
+        updated_subtasks: list[SubTask] = []
+        for subtask in subtasks:
+            if subtask["status"] != "review":
+                updated_subtasks.append(subtask)
+                continue
 
-    updated_subtasks: list[SubTask] = []
-    for subtask in subtasks:
-        if subtask["status"] != "review":
-            updated_subtasks.append(subtask)
-            continue
-
-        logger.info(
-            "pm_review: reviewing subtask %s (%s)", subtask["id"], subtask["title"]
-        )
-        try:
-            result = await review_with_pm(
-                state, subtask, meshwiki_client, github_client
-            )
-        except Exception as exc:
-            logger.error(
-                "pm_review: review failed for subtask %s: %s", subtask["id"], exc
-            )
-            # Mark as failed so route_after_pm_review escalates rather than
-            # silently auto-approving unreviewed code.
-            updated_subtask = SubTask(
-                **{**subtask, "status": "failed", "review_feedback": str(exc)}
-            )
-            updated_subtasks.append(updated_subtask)
-            try:
-                await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
-            except Exception as transition_exc:
-                logger.warning(
-                    "pm_review: failed to transition %s to failed: %s",
-                    subtask["wiki_page"],
-                    transition_exc,
-                )
-            continue
-
-        decision: str = result.get("decision", "changes_requested")
-        feedback: str | None = result.get("feedback")
-
-        if decision == "approved":
-            if get_settings().auto_merge and subtask.get("pr_url"):
-                pr_number = subtask.get("pr_number") or _extract_pr_number(
-                    subtask["pr_url"]
-                )
-                if pr_number:
-                    try:
-                        await github_client.merge_pr(pr_number)
-                        logger.info(
-                            "pm_review: auto-merged PR #%d for subtask %s",
-                            pr_number,
-                            subtask["id"],
-                        )
-                        try:
-                            await meshwiki_client.transition_task(
-                                subtask["wiki_page"], "merged"
-                            )
-                        except Exception as exc:
-                            logger.warning(
-                                "pm_review: failed to transition %s to merged: %s",
-                                subtask["wiki_page"],
-                                exc,
-                            )
-                    except Exception as exc:
-                        logger.warning(
-                            "pm_review: auto-merge failed for PR #%d: %s",
-                            pr_number,
-                            exc,
-                        )
-            updated_subtask = SubTask(
-                **{**subtask, "status": "merged", "review_feedback": feedback}
-            )
-            logger.info("pm_review: subtask %s approved", subtask["id"])
-        else:
-            updated_subtask = SubTask(
-                **{
-                    **subtask,
-                    "status": "changes_requested",
-                    "review_feedback": feedback,
-                    "attempt": subtask.get("attempt", 0) + 1,
-                }
-            )
             logger.info(
-                "pm_review: subtask %s changes_requested: %s", subtask["id"], feedback
+                "pm_review: reviewing subtask %s (%s)", subtask["id"], subtask["title"]
             )
-
-        updated_subtasks.append(updated_subtask)
-
-        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
-
-        if decision == "approved":
-            pm_section = (
-                f"## PM Review — {timestamp}\n\n"
-                f"✅ **Approved**\n\n"
-                f"{feedback or 'Looks good.'}\n"
-            )
-        else:
-            pm_section = (
-                f"## PM Review — {timestamp}\n\n"
-                f"❌ **Changes requested**\n\n"
-                f"{feedback or 'See comments above.'}\n"
-            )
-
-        fm_updates: dict | None = None
-        if decision != "approved":
-            fm_updates = {"rework_count": updated_subtask.get("attempt", 1)}
-        try:
-            await meshwiki_client.append_to_page(
-                subtask["wiki_page"], pm_section, frontmatter_updates=fm_updates
-            )
-        except Exception as exc:
-            logger.warning("pm_review: failed to append review to wiki: %s", exc)
-
-        if decision != "approved":
             try:
-                await meshwiki_client.transition_task(
-                    subtask["wiki_page"], "in_progress"
+                result = await review_with_pm(
+                    state, subtask, meshwiki_client, github_client
                 )
             except Exception as exc:
-                logger.warning(
-                    "pm_review: failed to transition %s back to in_progress: %s",
-                    subtask["wiki_page"],
-                    exc,
+                logger.error(
+                    "pm_review: review failed for subtask %s: %s", subtask["id"], exc
+                )
+                updated_subtask = SubTask(
+                    **{**subtask, "status": "failed", "review_feedback": str(exc)}
+                )
+                updated_subtasks.append(updated_subtask)
+                try:
+                    await meshwiki_client.transition_task(
+                        subtask["wiki_page"], "failed"
+                    )
+                except Exception as transition_exc:
+                    logger.warning(
+                        "pm_review: failed to transition %s to failed: %s",
+                        subtask["wiki_page"],
+                        transition_exc,
+                    )
+                continue
+
+            decision: str = result.get("decision", "changes_requested")
+            feedback: str | None = result.get("feedback")
+
+            if decision == "approved":
+                if get_settings().auto_merge and subtask.get("pr_url"):
+                    pr_number = subtask.get("pr_number") or _extract_pr_number(
+                        subtask["pr_url"]
+                    )
+                    if pr_number:
+                        try:
+                            await github_client.merge_pr(pr_number)
+                            logger.info(
+                                "pm_review: auto-merged PR #%d for subtask %s",
+                                pr_number,
+                                subtask["id"],
+                            )
+                            try:
+                                await meshwiki_client.transition_task(
+                                    subtask["wiki_page"], "merged"
+                                )
+                            except Exception as exc:
+                                logger.warning(
+                                    "pm_review: failed to transition %s to merged: %s",
+                                    subtask["wiki_page"],
+                                    exc,
+                                )
+                        except Exception as exc:
+                            logger.warning(
+                                "pm_review: auto-merge failed for PR #%d: %s",
+                                pr_number,
+                                exc,
+                            )
+                updated_subtask = SubTask(
+                    **{**subtask, "status": "merged", "review_feedback": feedback}
+                )
+                logger.info("pm_review: subtask %s approved", subtask["id"])
+            else:
+                updated_subtask = SubTask(
+                    **{
+                        **subtask,
+                        "status": "changes_requested",
+                        "review_feedback": feedback,
+                        "attempt": subtask.get("attempt", 0) + 1,
+                    }
+                )
+                logger.info(
+                    "pm_review: subtask %s changes_requested: %s",
+                    subtask["id"],
+                    feedback,
                 )
 
-    return {"subtasks": updated_subtasks}
+            updated_subtasks.append(updated_subtask)
+
+            timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
+
+            if decision == "approved":
+                pm_section = (
+                    f"## PM Review — {timestamp}\n\n"
+                    f"✅ **Approved**\n\n"
+                    f"{feedback or 'Looks good.'}\n"
+                )
+            else:
+                pm_section = (
+                    f"## PM Review — {timestamp}\n\n"
+                    f"❌ **Changes requested**\n\n"
+                    f"{feedback or 'See comments above.'}\n"
+                )
+
+            fm_updates: dict | None = None
+            if decision != "approved":
+                fm_updates = {"rework_count": updated_subtask.get("attempt", 1)}
+            try:
+                await meshwiki_client.append_to_page(
+                    subtask["wiki_page"], pm_section, frontmatter_updates=fm_updates
+                )
+            except Exception as exc:
+                logger.warning("pm_review: failed to append review to wiki: %s", exc)
+
+            if decision != "approved":
+                try:
+                    await meshwiki_client.transition_task(
+                        subtask["wiki_page"], "in_progress"
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "pm_review: failed to transition %s back to in_progress: %s",
+                        subtask["wiki_page"],
+                        exc,
+                    )
+
+        return {"subtasks": updated_subtasks}

--- a/orchestrator/factory/nodes/task_intake.py
+++ b/orchestrator/factory/nodes/task_intake.py
@@ -34,8 +34,8 @@ async def task_intake_node(state: FactoryState) -> dict:
     task_wiki_page: str = state.get("task_wiki_page", "")
     logger.info("task_intake: loading task %s", task_wiki_page)
 
-    meshwiki_client = MeshWikiClient()
-    page = await meshwiki_client.get_page(task_wiki_page)
+    async with MeshWikiClient() as meshwiki_client:
+        page = await meshwiki_client.get_page(task_wiki_page)
 
     if page is None:
         logger.error("task_intake: task page %s not found", task_wiki_page)

--- a/orchestrator/factory/state.py
+++ b/orchestrator/factory/state.py
@@ -53,7 +53,9 @@ class SubTask(TypedDict):
     token_budget: int  # max tokens for the grinder session
     tokens_used: int
     review_feedback: str | None  # PM feedback for rejected subtasks
-    code_skeleton: str | None  # starter code template provided by PM during decomposition
+    code_skeleton: (
+        str | None
+    )  # starter code template provided by PM during decomposition
 
 
 class FactoryState(TypedDict):

--- a/orchestrator/factory/webhook_server.py
+++ b/orchestrator/factory/webhook_server.py
@@ -30,48 +30,58 @@ async def _resume_interrupted_tasks(graph, saver, settings) -> None:
     3. If yes, call ainvoke(None) with the same thread_id — LangGraph resumes
        from the last node boundary rather than restarting from scratch.
     """
-    client = MeshWikiClient(settings.meshwiki_url, settings.meshwiki_api_key)
-    all_factory_tasks: list[dict] = []
-    for status in ("in_progress", "review"):
-        try:
-            tasks = await client.list_tasks(status=status)
-        except Exception as exc:
-            logger.warning("factory: could not fetch %s tasks on startup: %s", status, exc)
-            continue
-        all_factory_tasks.extend(
-            t for t in tasks
-            if t.get("metadata", {}).get("assignee") == "factory"
-            or t.get("assignee") == "factory"  # flat format (defensive)
+    async with MeshWikiClient(
+        settings.meshwiki_url, settings.meshwiki_api_key
+    ) as client:
+        all_factory_tasks: list[dict] = []
+        for status in ("in_progress", "review"):
+            try:
+                tasks = await client.list_tasks(status=status)
+            except Exception as exc:
+                logger.warning(
+                    "factory: could not fetch %s tasks on startup: %s", status, exc
+                )
+                continue
+            all_factory_tasks.extend(
+                t
+                for t in tasks
+                if t.get("metadata", {}).get("assignee") == "factory"
+                or t.get("assignee") == "factory"  # flat format (defensive)
+            )
+
+        if not all_factory_tasks:
+            return
+
+        factory_tasks = all_factory_tasks
+        logger.info(
+            "factory: found %d active factory task(s) on startup", len(factory_tasks)
         )
+        for task in factory_tasks:
+            page_name = task.get("name", "")
+            if not page_name:
+                continue
 
-    if not all_factory_tasks:
-        return
+            config = {"configurable": {"thread_id": page_name}}
+            checkpoint_tuple = await saver.aget_tuple(config)
+            if checkpoint_tuple is None:
+                logger.info(
+                    "factory: no checkpoint for %s — skipping resume", page_name
+                )
+                continue
 
-    factory_tasks = all_factory_tasks
-    logger.info("factory: found %d active factory task(s) on startup", len(factory_tasks))
-    for task in factory_tasks:
-        page_name = task.get("name", "")
-        if not page_name:
-            continue
+            logger.info(
+                "factory: resuming interrupted task %s from checkpoint", page_name
+            )
 
-        config = {"configurable": {"thread_id": page_name}}
-        # Check whether a checkpoint exists for this thread.
-        checkpoint_tuple = await saver.aget_tuple(config)
-        if checkpoint_tuple is None:
-            logger.info("factory: no checkpoint for %s — skipping resume", page_name)
-            continue
+            def _log_exc(t: asyncio.Task, name: str = page_name) -> None:
+                if not t.cancelled() and (exc := t.exception()):
+                    logger.error("graph task %s failed: %s", name, exc, exc_info=exc)
 
-        logger.info("factory: resuming interrupted task %s from checkpoint", page_name)
-
-        def _log_exc(t: asyncio.Task, name: str = page_name) -> None:
-            if not t.cancelled() and (exc := t.exception()):
-                logger.error("graph task %s failed: %s", name, exc, exc_info=exc)
-
-        resume_task = asyncio.create_task(
-            graph.ainvoke(None, config=config),
-            name=f"graph:{page_name}:resume",
-        )
-        resume_task.add_done_callback(_log_exc)
+            resume_task = asyncio.create_task(
+                graph.ainvoke(None, config=config),
+                name=f"graph:{page_name}:resume",
+            )
+            resume_task.add_done_callback(_log_exc)
 
 
 @asynccontextmanager
@@ -80,7 +90,10 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     async with AsyncSqliteSaver.from_conn_string(settings.checkpoint_db) as saver:
         app.state.graph = build_graph(saver)
-        logger.info("factory: graph initialised with SQLite checkpointer at %s", settings.checkpoint_db)
+        logger.info(
+            "factory: graph initialised with SQLite checkpointer at %s",
+            settings.checkpoint_db,
+        )
         await _resume_interrupted_tasks(app.state.graph, saver, settings)
         yield
     logger.info("factory: SQLite checkpointer closed")
@@ -192,7 +205,9 @@ async def receive_webhook(
     page_name: str = payload.get("page", "")
     data: dict[str, Any] = payload.get("data", {})
 
-    logger.info("webhook: received event=%s (raw=%s) page=%s", event, raw_event, page_name)
+    logger.info(
+        "webhook: received event=%s (raw=%s) page=%s", event, raw_event, page_name
+    )
 
     if event == "task.assigned":
         # Skip subtask pages — they are driven by their parent graph thread.

--- a/orchestrator/tests/test_http_clients.py
+++ b/orchestrator/tests/test_http_clients.py
@@ -1,0 +1,74 @@
+"""Tests verifying that MeshWikiClient and GitHubClient share a single httpx.AsyncClient."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.integrations.github_client import GitHubClient
+from factory.integrations.meshwiki_client import MeshWikiClient
+
+
+class TestMeshWikiClientSharedClient:
+    def test_creates_one_async_client(self) -> None:
+        """MeshWikiClient.__init__ must create exactly one httpx.AsyncClient."""
+        with patch(
+            "factory.integrations.meshwiki_client.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _ = MeshWikiClient(base_url="http://localhost", api_key="tok")
+            assert mock_cls.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_close_calls_aclose(self) -> None:
+        """close() must call aclose() on the underlying AsyncClient."""
+        with patch(
+            "factory.integrations.meshwiki_client.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            client = MeshWikiClient(base_url="http://localhost", api_key="tok")
+            await client.close()
+            mock_instance.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_calls_aclose_on_exit(self) -> None:
+        """Exiting async with must call aclose() on the underlying AsyncClient."""
+        with patch(
+            "factory.integrations.meshwiki_client.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            async with MeshWikiClient(base_url="http://localhost", api_key="tok"):
+                pass
+            mock_instance.aclose.assert_awaited_once()
+
+
+class TestGitHubClientSharedClient:
+    def test_creates_one_async_client(self) -> None:
+        """GitHubClient.__init__ must create exactly one httpx.AsyncClient."""
+        with patch("factory.integrations.github_client.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _ = GitHubClient(token="tok", repo="owner/repo")
+            assert mock_cls.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_close_calls_aclose(self) -> None:
+        """close() must call aclose() on the underlying AsyncClient."""
+        with patch("factory.integrations.github_client.httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            client = GitHubClient(token="tok", repo="owner/repo")
+            await client.close()
+            mock_instance.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_calls_aclose_on_exit(self) -> None:
+        """Exiting async with must call aclose() on the underlying AsyncClient."""
+        with patch("factory.integrations.github_client.httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            async with GitHubClient(token="tok", repo="owner/repo"):
+                pass
+            mock_instance.aclose.assert_awaited_once()

--- a/orchestrator/tests/test_nodes.py
+++ b/orchestrator/tests/test_nodes.py
@@ -62,6 +62,20 @@ def _make_subtask(**kwargs) -> SubTask:
     return subtask
 
 
+def _mock_client_for_cm(mock_client: AsyncMock) -> AsyncMock:
+    """Configure an AsyncMock to work as a context manager returning itself.
+
+    When MeshWikiClient/GitHubClient is patched with return_value=mock_client,
+    the code calls `async with mock_client as cm`.  By default AsyncMock's
+    __aenter__ returns a new AsyncMock (not mock_client), so method calls go
+    to the wrong object.  This helper fixes __aenter__ / __aexit__ so that
+    `cm is mock_client`.
+    """
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
 # ---------------------------------------------------------------------------
 # task_intake_node
 # ---------------------------------------------------------------------------
@@ -75,10 +89,14 @@ async def test_task_intake_node() -> None:
     mock_page = {
         "name": "Task_0042_test",
         "content": "## Requirements\nBuild the feature.",
-        "metadata": {"title": "Test Task Title", "status": "planned"},
+        "metadata": {
+            "title": "Test Task Title",
+            "status": "planned",
+            "assignee": "factory",
+        },
     }
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=mock_page)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -95,7 +113,7 @@ async def test_task_intake_node_page_not_found() -> None:
     """task_intake_node falls back gracefully when the page is not found."""
     state = _make_state()
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=None)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -125,7 +143,7 @@ async def test_decompose_node() -> None:
         title="Build something",
     )
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.create_page = AsyncMock(return_value={})
     mock_meshwiki.transition_task = AsyncMock(return_value={})
 
@@ -147,10 +165,9 @@ async def test_decompose_node() -> None:
     create_args = mock_meshwiki.create_page.call_args
     assert create_args[0][0] == "Task_0042_Sub_01_build"
 
-    # Should have transitioned subtask to planned and parent to decomposed
-    assert mock_meshwiki.transition_task.await_count == 2
+    # Should have transitioned the parent task to decomposed
+    assert mock_meshwiki.transition_task.await_count == 1
     calls = [c[0] for c in mock_meshwiki.transition_task.call_args_list]
-    assert ("Task_0042_Sub_01_build", "planned") in calls
     assert ("Task_0042_test", "decomposed") in calls
 
 
@@ -159,7 +176,7 @@ async def test_decompose_node_no_subtasks() -> None:
     """decompose_node handles empty subtask list from PM agent."""
     state = _make_state()
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.create_page = AsyncMock(return_value={})
     mock_meshwiki.transition_task = AsyncMock(return_value={})
 
@@ -197,10 +214,10 @@ async def test_pm_review_node_approved() -> None:
     )
     state = _make_state(subtasks=[review_subtask])
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.get_page = AsyncMock(return_value={"content": "criteria"})
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr_diff = AsyncMock(return_value="diff content")
 
     with (
@@ -229,10 +246,10 @@ async def test_pm_review_node_changes_requested() -> None:
     )
     state = _make_state(subtasks=[review_subtask])
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.get_page = AsyncMock(return_value=None)
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
 
     with (
         patch("factory.nodes.pm_review.MeshWikiClient", return_value=mock_meshwiki),
@@ -263,8 +280,8 @@ async def test_pm_review_node_skips_non_review_subtasks() -> None:
     )
     state = _make_state(subtasks=[pending_subtask])
 
-    mock_meshwiki = AsyncMock()
-    mock_github = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
+    mock_github = _mock_client_for_cm(AsyncMock())
 
     with (
         patch("factory.nodes.pm_review.MeshWikiClient", return_value=mock_meshwiki),
@@ -331,12 +348,13 @@ async def test_task_intake_direct_grind() -> None:
             "title": "Direct Grind Task",
             "status": "planned",
             "skip_decomposition": "true",
+            "assignee": "factory",
             "expected_files": ["src/meshwiki/main.py"],
             "token_budget": "30000",
         },
     }
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=mock_page)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -377,10 +395,11 @@ async def test_task_intake_direct_grind_boolean_flag() -> None:
             "title": "Bool Flag Task",
             "status": "planned",
             "skip_decomposition": True,
+            "assignee": "factory",
         },
     }
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=mock_page)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -447,7 +466,7 @@ async def test_finalize_node() -> None:
     """finalize_node calls transition_task with 'done' and returns completed status."""
     state = _make_state(cost_usd=0.0042)
 
-    mock_client_instance = AsyncMock()
+    mock_client_instance = _mock_client_for_cm(AsyncMock())
     mock_client_instance.transition_task = AsyncMock(return_value={})
     mock_client_cls = MagicMock(return_value=mock_client_instance)
 
@@ -467,7 +486,7 @@ async def test_finalize_node_handles_client_error() -> None:
     """finalize_node logs and swallows MeshWiki client errors, still returns completed."""
     state = _make_state()
 
-    mock_client_instance = AsyncMock()
+    mock_client_instance = _mock_client_for_cm(AsyncMock())
     mock_client_instance.transition_task = AsyncMock(
         side_effect=RuntimeError("network error")
     )
@@ -560,7 +579,7 @@ async def test_merge_check_node_merged_pr() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 10, "state": "closed", "merged": True}
     )
@@ -583,7 +602,7 @@ async def test_merge_check_node_closed_not_merged() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 11, "state": "closed", "merged": False}
     )
@@ -605,7 +624,7 @@ async def test_merge_check_node_still_open() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 12, "state": "open", "merged": False}
     )
@@ -628,7 +647,7 @@ async def test_merge_check_node_pr_number_from_url() -> None:
     review_sub["pr_url"] = "https://github.com/owner/repo/pull/42"
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 42, "state": "closed", "merged": True}
     )
@@ -692,7 +711,7 @@ async def test_merge_check_node_api_error_continues() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         side_effect=httpx.HTTPStatusError(
             "404 Not Found",
@@ -735,7 +754,7 @@ async def test_merge_check_node_multiple_subtasks() -> None:
             return {"number": 20, "state": "closed", "merged": True}
         return {"number": 21, "state": "open", "merged": False}
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(side_effect=_fake_get_pr)
 
     with patch("factory.nodes.merge_check.GitHubClient", return_value=mock_github):

--- a/orchestrator/tests/test_pipeline.py
+++ b/orchestrator/tests/test_pipeline.py
@@ -9,12 +9,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
 from langgraph.checkpoint.memory import MemorySaver
 
 from factory.graph import build_graph
 from factory.state import FactoryState, SubTask
-
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary
- Refactor `MeshWikiClient` and `GitHubClient` to hold a single `httpx.AsyncClient` instance created in `__init__`
- Add `async close()`, `__aenter__`, `__aexit__` methods to both clients for proper lifecycle management
- Update all node callers to use `async with` context manager pattern

## Changes
- `orchestrator/factory/integrations/meshwiki_client.py` — shared `self._client`
- `orchestrator/factory/integrations/github_client.py` — shared `self._client`
- All node callers updated to use `async with` pattern
- `orchestrator/tests/test_http_clients.py` — **new file** with 6 tests
- `orchestrator/tests/test_nodes.py` — added `_mock_client_for_cm()` helper

## Test Results
- `test_http_clients.py`: 6 passed
- `test_meshwiki_client.py`: 7 passed  
- `test_github_client.py`: 19 passed
- `test_nodes.py`: 22 passed, 1 pre-existing failure