### PR TITLE
[Factory] Epic_0001 TASK002+TASK003: concurrency cap + httpx client sharing

### DIFF
--- a/orchestrator/factory/config.py
+++ b/orchestrator/factory/config.py
@@ -1,8 +1,13 @@
 """Configuration for the factory orchestrator service."""
 
+import os
 from functools import lru_cache
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+FACTORY_MAX_CONCURRENT_SANDBOXES: int = int(
+    os.getenv("FACTORY_MAX_CONCURRENT_SANDBOXES", "3")
+)
 
 
 class Settings(BaseSettings):

--- a/orchestrator/factory/integrations/github_client.py
+++ b/orchestrator/factory/integrations/github_client.py
@@ -28,15 +28,30 @@ class GitHubClient:
         settings = get_settings()
         self._token = token or settings.github_token
         self._repo = repo or settings.github_repo
+        self._client = httpx.AsyncClient(
+            base_url=_BASE_URL,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=30.0,
+        )
 
     def _headers(self) -> dict[str, str]:
-        headers: dict[str, str] = {
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
+        headers: dict[str, str] = {}
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"
         return headers
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "GitHubClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close()
 
     async def get_pr(self, pr_number: int) -> dict:
         """Fetch full pull request metadata.
@@ -50,11 +65,10 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers())
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}"
+        resp = await self._client.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
 
     async def get_pr_diff(self, pr_number: int) -> str:
         """Fetch the unified diff for a pull request.
@@ -68,12 +82,11 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}"
+        url = f"/repos/{self._repo}/pulls/{pr_number}"
         headers = {**self._headers(), "Accept": "application/vnd.github.v3.diff"}
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=headers)
-            resp.raise_for_status()
-            return resp.text
+        resp = await self._client.get(url, headers=headers)
+        resp.raise_for_status()
+        return resp.text
 
     async def create_pr_comment(self, pr_number: int, body: str) -> dict:
         """Post an issue comment on a pull request.
@@ -88,15 +101,14 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/issues/{pr_number}/comments"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"body": body},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/issues/{pr_number}/comments"
+        resp = await self._client.post(
+            url,
+            headers=self._headers(),
+            json={"body": body},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     async def request_changes(self, pr_number: int, body: str) -> dict:
         """Submit a 'REQUEST_CHANGES' review on a pull request.
@@ -111,15 +123,14 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}/reviews"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"event": "REQUEST_CHANGES", "body": body},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}/reviews"
+        resp = await self._client.post(
+            url,
+            headers=self._headers(),
+            json={"event": "REQUEST_CHANGES", "body": body},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     async def approve_pr(self, pr_number: int, body: str = "") -> dict:
         """Submit an 'APPROVE' review on a pull request.
@@ -134,18 +145,20 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}/reviews"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"event": "APPROVE", "body": body},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}/reviews"
+        resp = await self._client.post(
+            url,
+            headers=self._headers(),
+            json={"event": "APPROVE", "body": body},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     async def merge_pr(
-        self, pr_number: int, commit_title: str = "", merge_method: str = "squash"
+        self,
+        pr_number: int,
+        commit_title: str = "",
+        merge_method: str = "squash",
     ) -> dict:
         """Merge a pull request via the GitHub API.
 
@@ -160,14 +173,13 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}/merge"
+        url = f"/repos/{self._repo}/pulls/{pr_number}/merge"
         body: dict = {"merge_method": merge_method}
         if commit_title:
             body["commit_title"] = commit_title
-        async with httpx.AsyncClient() as client:
-            resp = await client.put(url, headers=self._headers(), json=body)
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.put(url, headers=self._headers(), json=body)
+        resp.raise_for_status()
+        return resp.json()
 
     async def get_file_content(self, path: str, ref: str = "staging") -> str:
         """Fetch raw content of a file from the repository.
@@ -185,11 +197,10 @@ class GitHubClient:
         """
         import base64
 
-        url = f"{_BASE_URL}/repos/{self._repo}/contents/{path}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers(), params={"ref": ref})
-            resp.raise_for_status()
-            data = resp.json()
+        url = f"/repos/{self._repo}/contents/{path}"
+        resp = await self._client.get(url, headers=self._headers(), params={"ref": ref})
+        resp.raise_for_status()
+        data = resp.json()
         if data.get("type") != "file":
             raise ValueError(f"Not a file: {path!r} (type={data.get('type')})")
         return base64.b64decode(data["content"]).decode("utf-8", errors="replace")
@@ -206,15 +217,14 @@ class GitHubClient:
         Raises:
             httpx.HTTPStatusError: On non-2xx responses.
         """
-        url = f"{_BASE_URL}/repos/{self._repo}/pulls/{pr_number}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.patch(
-                url,
-                headers=self._headers(),
-                json={"state": "closed"},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        url = f"/repos/{self._repo}/pulls/{pr_number}"
+        resp = await self._client.patch(
+            url,
+            headers=self._headers(),
+            json={"state": "closed"},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
 
 def _extract_pr_number(pr_url: str) -> int | None:

--- a/orchestrator/factory/integrations/meshwiki_client.py
+++ b/orchestrator/factory/integrations/meshwiki_client.py
@@ -1,7 +1,15 @@
 """Async HTTP client wrapping the MeshWiki JSON API."""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
+
+import httpx
+
+from ..config import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 def _patch_frontmatter(content: str, updates: dict[str, Any]) -> str:
@@ -17,7 +25,7 @@ def _patch_frontmatter(content: str, updates: dict[str, Any]) -> str:
     if close == -1:
         return content
     front_lines = content[4:close].split("\n")
-    body = content[close + 5:]
+    body = content[close + 5 :]
 
     updated_keys: set[str] = set()
     new_front: list[str] = []
@@ -36,12 +44,6 @@ def _patch_frontmatter(content: str, updates: dict[str, Any]) -> str:
 
     return "---\n" + "\n".join(new_front) + "\n---\n" + body
 
-import httpx
-
-from ..config import get_settings
-
-logger = logging.getLogger(__name__)
-
 
 class MeshWikiClient:
     """Async client for the MeshWiki JSON API (``/api/v1/``)."""
@@ -50,12 +52,27 @@ class MeshWikiClient:
         settings = get_settings()
         self._base_url = (base_url or settings.meshwiki_url).rstrip("/")
         self._api_key = api_key or settings.meshwiki_api_key
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=self._headers(),
+            timeout=30.0,
+        )
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
         return headers
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "MeshWikiClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close()
 
     async def get_page(self, name: str) -> dict | None:
         """
@@ -65,12 +82,11 @@ class MeshWikiClient:
         the page does not exist.
         """
         url = f"{self._base_url}/api/v1/pages/{name}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers())
-            if resp.status_code == 404:
-                return None
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.get(url)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
 
     async def create_page(self, name: str, content: str) -> dict:
         """
@@ -80,14 +96,12 @@ class MeshWikiClient:
         Returns the saved page dict.
         """
         url = f"{self._base_url}/api/v1/pages/{name}"
-        async with httpx.AsyncClient() as client:
-            resp = await client.put(
-                url,
-                headers=self._headers(),
-                json={"name": name, "content": content},
-            )
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.put(
+            url,
+            json={"name": name, "content": content},
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     async def transition_task(
         self,
@@ -110,14 +124,9 @@ class MeshWikiClient:
         payload: dict[str, Any] = {"status": status}
         if extra_fields:
             payload.update(extra_fields)
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json=payload,
-            )
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.post(url, json=payload)
+        resp.raise_for_status()
+        return resp.json()
 
     async def relay_terminal(self, task_name: str, data: str) -> None:
         """Relay a raw PTY / stdout chunk to the MeshWiki live terminal stream.
@@ -131,8 +140,7 @@ class MeshWikiClient:
         """
         url = f"{self._base_url}/api/v1/tasks/{task_name}/terminal"
         try:
-            async with httpx.AsyncClient() as client:
-                await client.post(url, headers=self._headers(), json={"data": data})
+            await self._client.post(url, json={"data": data})
         except Exception as exc:
             logger.debug("terminal relay failed (non-critical): %s", exc)
 
@@ -146,10 +154,9 @@ class MeshWikiClient:
         params: dict[str, str] = {}
         if status is not None:
             params["status"] = status
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=self._headers(), params=params)
-            resp.raise_for_status()
-            return resp.json()
+        resp = await self._client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()
 
     async def rename_page(self, old_name: str, new_name: str) -> None:
         """Move a wiki page to a new name/location.
@@ -159,13 +166,11 @@ class MeshWikiClient:
             new_name: New page name (may include new path segments).
         """
         url = f"{self._base_url}/api/v1/pages/{old_name}/rename"
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=self._headers(),
-                json={"new_name": new_name},
-            )
-            resp.raise_for_status()
+        resp = await self._client.post(
+            url,
+            json={"new_name": new_name},
+        )
+        resp.raise_for_status()
 
     async def append_to_page(
         self,
@@ -177,7 +182,7 @@ class MeshWikiClient:
         Append content_to_append to the body of the named wiki page.
 
         Gets the current page content, optionally patches frontmatter fields,
-        strips trailing whitespace, appends "\\n\\n" + content_to_append, then
+        strips trailing whitespace, appends "\n\n" + content_to_append, then
         PUTs the updated content back in a single round-trip.
         """
         page = await self.get_page(page_name)

--- a/orchestrator/factory/nodes/assign.py
+++ b/orchestrator/factory/nodes/assign.py
@@ -4,6 +4,7 @@ import logging
 
 from langgraph.types import Send
 
+from ..config import FACTORY_MAX_CONCURRENT_SANDBOXES
 from ..state import FactoryState, SubTask
 
 logger = logging.getLogger(__name__)
@@ -31,26 +32,42 @@ def route_grinders(state: FactoryState) -> list[Send]:
     with non-overlapping ``files_touched`` sets are dispatched in this round.
     The rest remain 'pending' and will be picked up in a subsequent round.
 
+    Respects FACTORY_MAX_CONCURRENT_SANDBOXES cap — only dispatches up to
+    (cap - len(active_grinders)) subtasks in this round.
+
     Returns:
         List of ``Send`` commands, one per non-conflicting pending subtask.
     """
+    active = state.get("active_grinders", [])
+    slots_free = FACTORY_MAX_CONCURRENT_SANDBOXES - len(active)
+
+    if slots_free <= 0:
+        logger.info(
+            "assign_grinders: at concurrency cap (%d), no slots free",
+            FACTORY_MAX_CONCURRENT_SANDBOXES,
+        )
+        return []
+
     pending = [
         s
         for s in state.get("subtasks", [])
-        if s["status"] in ("pending", "changes_requested")
+        if s["status"] in ("pending", "changes_requested") and s["id"] not in active
     ]
 
     logger.info(
-        "assign_grinders: dispatching %d pending subtask(s) for task %s",
+        "assign_grinders: %d pending, %d active, %d slots free for task %s",
         len(pending),
+        len(active),
+        slots_free,
         state.get("task_wiki_page", "<unknown>"),
     )
 
-    # Detect file overlaps — serialize conflicting pairs
     assigned_files: set[str] = set()
     to_dispatch: list[SubTask] = []
 
     for subtask in pending:
+        if len(to_dispatch) >= slots_free:
+            break
         files = set(subtask.get("files_touched") or [])
         if files & assigned_files:
             logger.debug(

--- a/orchestrator/factory/nodes/decompose.py
+++ b/orchestrator/factory/nodes/decompose.py
@@ -99,64 +99,63 @@ async def decompose_node(state: FactoryState) -> dict:
         "decompose: decomposing task %s", state.get("task_wiki_page", "<unknown>")
     )
 
-    meshwiki_client = MeshWikiClient()
-    # github_client is not needed for decomposition
-    github_client = None
+    async with MeshWikiClient() as meshwiki_client:
+        result = await decompose_with_pm(state, meshwiki_client, None)
+        subtasks = result["subtasks"]
+        incremental_cost = result.get("incremental_cost_usd", 0.0)
 
-    result = await decompose_with_pm(state, meshwiki_client, github_client)
-    subtasks = result["subtasks"]
-    incremental_cost = result.get("incremental_cost_usd", 0.0)
+        parent_task = state.get("task_wiki_page", "")
 
-    parent_task = state.get("task_wiki_page", "")
-
-    # Guard: reject any subtask whose wiki_page is more than one level below
-    # the parent task — the PM must not create nested subtasks.
-    valid_subtasks = []
-    for subtask in subtasks:
-        page = subtask["wiki_page"]
-        expected_prefix = parent_task + "/"
-        relative = (
-            page[len(expected_prefix) :] if page.startswith(expected_prefix) else page
-        )
-        if "/" in relative:
-            logger.error(
-                "decompose: rejecting nested subtask %s (parent=%s) — "
-                "subtask wiki_page must be a direct child of the parent task",
-                page,
-                parent_task,
+        # Guard: reject any subtask whose wiki_page is more than one level below
+        # the parent task — the PM must not create nested subtasks.
+        valid_subtasks = []
+        for subtask in subtasks:
+            page = subtask["wiki_page"]
+            expected_prefix = parent_task + "/"
+            relative = (
+                page[len(expected_prefix):]
+                if page.startswith(expected_prefix)
+                else page
             )
-            continue
-        valid_subtasks.append(subtask)
+            if "/" in relative:
+                logger.error(
+                    "decompose: rejecting nested subtask %s (parent=%s) — "
+                    "subtask wiki_page must be a direct child of the parent task",
+                    page,
+                    parent_task,
+                )
+                continue
+            valid_subtasks.append(subtask)
 
-    if len(valid_subtasks) != len(subtasks):
-        logger.warning(
-            "decompose: dropped %d nested subtask(s) out of %d",
-            len(subtasks) - len(valid_subtasks),
-            len(subtasks),
-        )
-    subtasks = valid_subtasks
+        if len(valid_subtasks) != len(subtasks):
+            logger.warning(
+                "decompose: dropped %d nested subtask(s) out of %d",
+                len(subtasks) - len(valid_subtasks),
+                len(subtasks),
+            )
+        subtasks = valid_subtasks
 
-    for subtask in subtasks:
-        page_content = _build_subtask_page(subtask, parent_task)
+        for subtask in subtasks:
+            page_content = _build_subtask_page(subtask, parent_task)
+            try:
+                await meshwiki_client.create_page(subtask["wiki_page"], page_content)
+                logger.info("decompose: created wiki page %s", subtask["wiki_page"])
+            except Exception as exc:
+                logger.error(
+                    "decompose: failed to create wiki page %s: %s",
+                    subtask["wiki_page"],
+                    exc,
+                )
+
         try:
-            await meshwiki_client.create_page(subtask["wiki_page"], page_content)
-            logger.info("decompose: created wiki page %s", subtask["wiki_page"])
+            await meshwiki_client.transition_task(parent_task, "decomposed")
+            logger.info(
+                "decompose: transitioned parent task %s to decomposed", parent_task
+            )
         except Exception as exc:
             logger.error(
-                "decompose: failed to create wiki page %s: %s",
-                subtask["wiki_page"],
-                exc,
+                "decompose: failed to transition parent task %s: %s", parent_task, exc
             )
-
-        # Page is created with status: planned already — no transition needed.
-
-    try:
-        await meshwiki_client.transition_task(parent_task, "decomposed")
-        logger.info("decompose: transitioned parent task %s to decomposed", parent_task)
-    except Exception as exc:
-        logger.error(
-            "decompose: failed to transition parent task %s: %s", parent_task, exc
-        )
 
     return {
         "subtasks": subtasks,

--- a/orchestrator/factory/nodes/escalate.py
+++ b/orchestrator/factory/nodes/escalate.py
@@ -31,59 +31,55 @@ async def escalate_node(state: FactoryState) -> dict:
         Partial state update with updated ``subtasks``, ``graph_status``, and
         ``escalation_decision``.
     """
-    client = MeshWikiClient()
+    async with MeshWikiClient() as client:
+        failed_ids = state.get("failed_subtask_ids", [])
+        failed_subtasks = [s for s in state["subtasks"] if s["id"] in failed_ids]
 
-    failed_ids = state.get("failed_subtask_ids", [])
-    failed_subtasks = [s for s in state["subtasks"] if s["id"] in failed_ids]
+        logger.warning(
+            "escalate: escalating task %s (failed subtasks: %s)",
+            state.get("task_wiki_page", "<unknown>"),
+            failed_ids,
+        )
 
-    logger.warning(
-        "escalate: escalating task %s (failed subtasks: %s)",
-        state.get("task_wiki_page", "<unknown>"),
-        failed_ids,
-    )
+        retriable = [s for s in failed_subtasks if s["attempt"] < s["max_attempts"] - 1]
 
-    # Check which failed subtasks still have retries remaining
-    retriable = [s for s in failed_subtasks if s["attempt"] < s["max_attempts"] - 1]
-
-    # Append escalation note to the task wiki page
-    try:
-        page = await client.get_page(state["task_wiki_page"])
-        if page:
-            content = page.get("content", "")
-            note = f"\n\n## Escalation\n\nFailed subtasks: {', '.join(failed_ids)}\n"
-            if retriable:
-                note += f"Retrying: {', '.join(s['id'] for s in retriable)}\n"
-            await client.create_page(state["task_wiki_page"], content + note)
-    except Exception as exc:
-        logger.error("escalate: failed to update task page: %s", exc)
-
-    # Transition retriable subtask wiki pages back to in_progress so that
-    # grind_node can later transition them to review (failed->review is invalid).
-    for s in retriable:
         try:
-            await client.transition_task(s["wiki_page"], "in_progress")
-            logger.info(
-                "escalate: transitioned %s back to in_progress for retry", s["id"]
-            )
+            page = await client.get_page(state["task_wiki_page"])
+            if page:
+                content = page.get("content", "")
+                note = (
+                    f"\n\n## Escalation\n\nFailed subtasks: {', '.join(failed_ids)}\n"
+                )
+                if retriable:
+                    note += f"Retrying: {', '.join(s['id'] for s in retriable)}\n"
+                await client.create_page(state["task_wiki_page"], content + note)
         except Exception as exc:
-            logger.warning(
-                "escalate: could not transition %s to in_progress: %s", s["id"], exc
-            )
+            logger.error("escalate: failed to update task page: %s", exc)
 
-    # Increment attempt count on retriable failed subtasks and reset status
-    retriable_ids = {s["id"] for s in retriable}
-    subtasks = []
-    for s in state["subtasks"]:
-        if s["id"] in retriable_ids:
-            subtasks.append({**s, "attempt": s["attempt"] + 1, "status": "pending"})
-        else:
-            subtasks.append(s)
+        for s in retriable:
+            try:
+                await client.transition_task(s["wiki_page"], "in_progress")
+                logger.info(
+                    "escalate: transitioned %s back to in_progress for retry", s["id"]
+                )
+            except Exception as exc:
+                logger.warning(
+                    "escalate: could not transition %s to in_progress: %s", s["id"], exc
+                )
 
-    decision = "retry" if retriable else "abandon"
-    logger.info("escalate: decision=%s", decision)
+        retriable_ids = {s["id"] for s in retriable}
+        subtasks = []
+        for s in state["subtasks"]:
+            if s["id"] in retriable_ids:
+                subtasks.append({**s, "attempt": s["attempt"] + 1, "status": "pending"})
+            else:
+                subtasks.append(s)
 
-    return {
-        "subtasks": subtasks,
-        "graph_status": "escalated",
-        "escalation_decision": decision,
-    }
+        decision = "retry" if retriable else "abandon"
+        logger.info("escalate: decision=%s", decision)
+
+        return {
+            "subtasks": subtasks,
+            "graph_status": "escalated",
+            "escalation_decision": decision,
+        }

--- a/orchestrator/factory/nodes/finalize.py
+++ b/orchestrator/factory/nodes/finalize.py
@@ -26,27 +26,26 @@ async def finalize_node(state: FactoryState) -> dict:
     total_cost = sum(state.get("incremental_costs_usd", []))
     total_cost += state.get("cost_usd", 0.0)
 
-    client = MeshWikiClient()
-
-    logger.info(
-        "finalize: completing task %s (cost: $%.4f)",
-        state.get("task_wiki_page", "<unknown>"),
-        total_cost,
-    )
-
-    task_page = state["task_wiki_page"]
-
-    try:
-        await client.transition_task(
-            task_page,
-            "done",
-            extra_fields={"cost_usd": str(round(total_cost, 4))},
-        )
-    except Exception as exc:
-        logger.error(
-            "finalize: failed to transition %s to done: %s",
-            task_page,
-            exc,
+    async with MeshWikiClient() as client:
+        logger.info(
+            "finalize: completing task %s (cost: $%.4f)",
+            state.get("task_wiki_page", "<unknown>"),
+            total_cost,
         )
 
-    return {"graph_status": "completed"}
+        task_page = state["task_wiki_page"]
+
+        try:
+            await client.transition_task(
+                task_page,
+                "done",
+                extra_fields={"cost_usd": str(round(total_cost, 4))},
+            )
+        except Exception as exc:
+            logger.error(
+                "finalize: failed to transition %s to done: %s",
+                task_page,
+                exc,
+            )
+
+        return {"graph_status": "completed"}

--- a/orchestrator/factory/nodes/grind.py
+++ b/orchestrator/factory/nodes/grind.py
@@ -16,14 +16,15 @@ async def grind_node(state: FactoryState) -> dict:
 
     Looks up the subtask identified by ``_current_subtask_id`` in state,
     invokes the grinder agentic loop, and returns a partial state update
-    with the updated subtasks list.
+    with the updated subtasks list and active_grinders.
 
     Args:
         state: Current FactoryState, must contain ``_current_subtask_id``.
 
     Returns:
         Partial state update with ``subtasks`` list where the current
-        subtask is replaced by the updated version from the grinder.
+        subtask is replaced by the updated version from the grinder,
+        and ``active_grinders`` with the subtask ID removed.
     """
     subtask_id = state.get("_current_subtask_id")
     subtask = next(
@@ -34,65 +35,80 @@ async def grind_node(state: FactoryState) -> dict:
         logger.error("grind_node: subtask %r not found in state", subtask_id)
         return {}
 
-    # Guard: rework with no feedback wastes a full sandbox run.
-    # Fail fast so escalate_node can handle it rather than grinding blindly.
-    if subtask.get("attempt", 0) > 0 and not subtask.get("review_feedback"):
-        logger.warning(
-            "grind_node: subtask %s is a rework (attempt %d) but review_feedback is empty — failing fast",
-            subtask_id,
-            subtask.get("attempt", 0),
-        )
-        error_log = list(subtask.get("error_log") or []) + [
-            "PM requested changes but provided no feedback — cannot rework"
-        ]
-        updated = {**subtask, "status": "failed", "error_log": error_log}
-        meshwiki_client = MeshWikiClient()
-        try:
-            await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
-        except Exception as exc:
-            logger.error(
-                "grind_node: failed to transition %s to failed: %s",
-                subtask["wiki_page"],
-                exc,
-            )
-        subtasks = [updated if s["id"] == subtask_id else s for s in state["subtasks"]]
-        return {"subtasks": subtasks}
-
+    active = list(state.get("active_grinders", []))
+    if subtask_id not in active:
+        active.append(subtask_id)
     logger.info(
-        "grind_node: running grinder for subtask %s (task %s)",
+        "grind_node: running grinder for subtask %s (task %s), active count: %d",
         subtask_id,
         state.get("task_wiki_page", "<unknown>"),
+        len(active),
     )
 
-    meshwiki_client = MeshWikiClient()
-    result = await grind_subtask(state, subtask, meshwiki_client)
-    updated = result["subtask"]
-    incremental_cost = result.get("incremental_cost_usd", 0.0)
+    async with MeshWikiClient() as meshwiki_client:
+        if subtask.get("attempt", 0) > 0 and not subtask.get("review_feedback"):
+            logger.warning(
+                "grind_node: subtask %s is a rework (attempt %d) but review_feedback is empty — failing fast",
+                subtask_id,
+                subtask.get("attempt", 0),
+            )
+            error_log = list(subtask.get("error_log") or []) + [
+                "PM requested changes but provided no feedback — cannot rework"
+            ]
+            updated = {**subtask, "status": "failed", "error_log": error_log}
+            try:
+                await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
+            except Exception as exc:
+                logger.error(
+                    "grind_node: failed to transition %s to failed: %s",
+                    subtask["wiki_page"],
+                    exc,
+                )
+            subtasks = [
+                updated if s["id"] == subtask_id else s for s in state["subtasks"]
+            ]
+            if subtask_id in active:
+                active.remove(subtask_id)
+            return {"subtasks": subtasks, "active_grinders": active}
 
-    # Transition the wiki task page to reflect the grinder outcome
-    final_status = updated.get("status", "failed")
-    extra_fields: dict = {}
-    if updated.get("pr_url"):
-        extra_fields["pr_url"] = updated["pr_url"]
-    if updated.get("branch_name"):
-        extra_fields["branch"] = updated["branch_name"]
-    try:
-        await meshwiki_client.transition_task(
-            updated["wiki_page"], final_status, extra_fields or None
-        )
-        logger.info(
-            "grind_node: transitioned %s to %s (pr=%s)",
-            updated["wiki_page"],
-            final_status,
-            updated.get("pr_url"),
-        )
-    except Exception as exc:
-        logger.error(
-            "grind_node: failed to transition %s to %s: %s",
-            updated["wiki_page"],
-            final_status,
-            exc,
-        )
+        result = await grind_subtask(state, subtask, meshwiki_client)
+        updated = result["subtask"]
+        incremental_cost = result.get("incremental_cost_usd", 0.0)
+
+        final_status = updated.get("status", "failed")
+        extra_fields: dict = {}
+        if updated.get("pr_url"):
+            extra_fields["pr_url"] = updated["pr_url"]
+        if updated.get("branch_name"):
+            extra_fields["branch"] = updated["branch_name"]
+        try:
+            await meshwiki_client.transition_task(
+                updated["wiki_page"], final_status, extra_fields or None
+            )
+            logger.info(
+                "grind_node: transitioned %s to %s (pr=%s)",
+                updated["wiki_page"],
+                final_status,
+                updated.get("pr_url"),
+            )
+        except Exception as exc:
+            logger.error(
+                "grind_node: failed to transition %s to %s: %s",
+                updated["wiki_page"],
+                final_status,
+                exc,
+            )
 
     subtasks = [updated if s["id"] == subtask_id else s for s in state["subtasks"]]
-    return {"subtasks": subtasks, "incremental_costs_usd": [incremental_cost]}
+    if subtask_id in active:
+        active.remove(subtask_id)
+    logger.info(
+        "grind_node: completed subtask %s, active count: %d",
+        subtask_id,
+        len(active),
+    )
+    return {
+        "subtasks": subtasks,
+        "active_grinders": active,
+        "incremental_costs_usd": [incremental_cost],
+    }

--- a/orchestrator/factory/nodes/merge_check.py
+++ b/orchestrator/factory/nodes/merge_check.py
@@ -36,58 +36,57 @@ async def merge_check_node(state: FactoryState) -> dict:
         state.get("task_wiki_page", "<unknown>"),
     )
 
-    github_client = GitHubClient()
-    subtasks = list(state["subtasks"])
+    async with GitHubClient() as github_client:
+        subtasks = list(state["subtasks"])
 
-    for i, subtask in enumerate(subtasks):
-        if subtask["status"] != "review":
-            continue
+        for i, subtask in enumerate(subtasks):
+            if subtask["status"] != "review":
+                continue
 
-        pr_number: int | None = subtask.get("pr_number")
+            pr_number: int | None = subtask.get("pr_number")
 
-        # Fall back to extracting from pr_url if pr_number is not set
-        if pr_number is None:
-            pr_url = subtask.get("pr_url")
-            if pr_url:
-                pr_number = _extract_pr_number(pr_url)
+            if pr_number is None:
+                pr_url = subtask.get("pr_url")
+                if pr_url:
+                    pr_number = _extract_pr_number(pr_url)
 
-        if pr_number is None:
-            logger.warning(
-                "merge_check: subtask %s in 'review' has no pr_number or pr_url — skipping",
-                subtask["id"],
-            )
-            continue
+            if pr_number is None:
+                logger.warning(
+                    "merge_check: subtask %s in 'review' has no pr_number or pr_url — skipping",
+                    subtask["id"],
+                )
+                continue
 
-        try:
-            pr = await github_client.get_pr(pr_number)
-        except httpx.HTTPStatusError as exc:
-            logger.error(
-                "merge_check: failed to fetch PR #%s for subtask %s: %s",
-                pr_number,
-                subtask["id"],
-                exc,
-            )
-            continue
+            try:
+                pr = await github_client.get_pr(pr_number)
+            except httpx.HTTPStatusError as exc:
+                logger.error(
+                    "merge_check: failed to fetch PR #%s for subtask %s: %s",
+                    pr_number,
+                    subtask["id"],
+                    exc,
+                )
+                continue
 
-        if pr.get("merged"):
-            logger.info(
-                "merge_check: PR #%s is merged for subtask %s",
-                pr_number,
-                subtask["id"],
-            )
-            subtasks[i] = {**subtask, "status": "merged"}
-        elif pr.get("state") == "closed":
-            logger.info(
-                "merge_check: PR #%s is closed (not merged) for subtask %s — marking failed",
-                pr_number,
-                subtask["id"],
-            )
-            subtasks[i] = {**subtask, "status": "failed"}
-        else:
-            logger.debug(
-                "merge_check: PR #%s is still open for subtask %s",
-                pr_number,
-                subtask["id"],
-            )
+            if pr.get("merged"):
+                logger.info(
+                    "merge_check: PR #%s is merged for subtask %s",
+                    pr_number,
+                    subtask["id"],
+                )
+                subtasks[i] = {**subtask, "status": "merged"}
+            elif pr.get("state") == "closed":
+                logger.info(
+                    "merge_check: PR #%s is closed (not merged) for subtask %s — marking failed",
+                    pr_number,
+                    subtask["id"],
+                )
+                subtasks[i] = {**subtask, "status": "failed"}
+            else:
+                logger.debug(
+                    "merge_check: PR #%s is still open for subtask %s",
+                    pr_number,
+                    subtask["id"],
+                )
 
-    return {"subtasks": subtasks}
+        return {"subtasks": subtasks}

--- a/orchestrator/factory/nodes/pm_review.py
+++ b/orchestrator/factory/nodes/pm_review.py
@@ -31,138 +31,138 @@ async def pm_review_node(state: FactoryState) -> dict:
         state.get("task_wiki_page", "<unknown>"),
     )
 
-    meshwiki_client = MeshWikiClient()
-    github_client = GitHubClient()
+    async with MeshWikiClient() as meshwiki_client, GitHubClient() as github_client:
+        subtasks: list[SubTask] = list(state.get("subtasks", []))
+        review_subtasks = [s for s in subtasks if s["status"] == "review"]
 
-    subtasks: list[SubTask] = list(state.get("subtasks", []))
-    review_subtasks = [s for s in subtasks if s["status"] == "review"]
+        logger.info("pm_review: %d subtask(s) in review status", len(review_subtasks))
 
-    logger.info("pm_review: %d subtask(s) in review status", len(review_subtasks))
+        updated_subtasks: list[SubTask] = []
+        total_incremental_cost: float = 0.0
+        for subtask in subtasks:
+            if subtask["status"] != "review":
+                updated_subtasks.append(subtask)
+                continue
 
-    updated_subtasks: list[SubTask] = []
-    total_incremental_cost: float = 0.0
-    for subtask in subtasks:
-        if subtask["status"] != "review":
-            updated_subtasks.append(subtask)
-            continue
-
-        logger.info(
-            "pm_review: reviewing subtask %s (%s)", subtask["id"], subtask["title"]
-        )
-        try:
-            result = await review_with_pm(
-                state, subtask, meshwiki_client, github_client
-            )
-        except Exception as exc:
-            logger.error(
-                "pm_review: review failed for subtask %s: %s", subtask["id"], exc
-            )
-            # Mark as failed so route_after_pm_review escalates rather than
-            # silently auto-approving unreviewed code.
-            updated_subtask = SubTask(
-                **{**subtask, "status": "failed", "review_feedback": str(exc)}
-            )
-            updated_subtasks.append(updated_subtask)
-            try:
-                await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
-            except Exception as transition_exc:
-                logger.warning(
-                    "pm_review: failed to transition %s to failed: %s",
-                    subtask["wiki_page"],
-                    transition_exc,
-                )
-            continue
-
-        decision: str = result.get("decision", "changes_requested")
-        feedback: str | None = result.get("feedback")
-        total_incremental_cost += result.get("incremental_cost_usd", 0.0)
-
-        if decision == "approved":
-            if get_settings().auto_merge and subtask.get("pr_url"):
-                pr_number = subtask.get("pr_number") or _extract_pr_number(
-                    subtask["pr_url"]
-                )
-                if pr_number:
-                    try:
-                        await github_client.merge_pr(pr_number)
-                        logger.info(
-                            "pm_review: auto-merged PR #%d for subtask %s",
-                            pr_number,
-                            subtask["id"],
-                        )
-                        try:
-                            await meshwiki_client.transition_task(
-                                subtask["wiki_page"], "merged"
-                            )
-                        except Exception as exc:
-                            logger.warning(
-                                "pm_review: failed to transition %s to merged: %s",
-                                subtask["wiki_page"],
-                                exc,
-                            )
-                    except Exception as exc:
-                        logger.warning(
-                            "pm_review: auto-merge failed for PR #%d: %s",
-                            pr_number,
-                            exc,
-                        )
-            updated_subtask = SubTask(
-                **{**subtask, "status": "merged", "review_feedback": feedback}
-            )
-            logger.info("pm_review: subtask %s approved", subtask["id"])
-        else:
-            updated_subtask = SubTask(
-                **{
-                    **subtask,
-                    "status": "changes_requested",
-                    "review_feedback": feedback,
-                    "attempt": subtask.get("attempt", 0) + 1,
-                }
-            )
             logger.info(
-                "pm_review: subtask %s changes_requested: %s", subtask["id"], feedback
+                "pm_review: reviewing subtask %s (%s)", subtask["id"], subtask["title"]
             )
-
-        updated_subtasks.append(updated_subtask)
-
-        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
-
-        if decision == "approved":
-            pm_section = (
-                f"## PM Review — {timestamp}\n\n"
-                f"✅ **Approved**\n\n"
-                f"{feedback or 'Looks good.'}\n"
-            )
-        else:
-            pm_section = (
-                f"## PM Review — {timestamp}\n\n"
-                f"❌ **Changes requested**\n\n"
-                f"{feedback or 'See comments above.'}\n"
-            )
-
-        fm_updates: dict | None = None
-        if decision != "approved":
-            fm_updates = {"rework_count": updated_subtask.get("attempt", 1)}
-        try:
-            await meshwiki_client.append_to_page(
-                subtask["wiki_page"], pm_section, frontmatter_updates=fm_updates
-            )
-        except Exception as exc:
-            logger.warning("pm_review: failed to append review to wiki: %s", exc)
-
-        if decision != "approved":
             try:
-                await meshwiki_client.transition_task(
-                    subtask["wiki_page"], "in_progress"
+                result = await review_with_pm(
+                    state, subtask, meshwiki_client, github_client
                 )
             except Exception as exc:
-                logger.warning(
-                    "pm_review: failed to transition %s back to in_progress: %s",
-                    subtask["wiki_page"],
-                    exc,
+                logger.error(
+                    "pm_review: review failed for subtask %s: %s", subtask["id"], exc
+                )
+                # Mark as failed so route_after_pm_review escalates rather than
+                # silently auto-approving unreviewed code.
+                updated_subtask = SubTask(
+                    **{**subtask, "status": "failed", "review_feedback": str(exc)}
+                )
+                updated_subtasks.append(updated_subtask)
+                try:
+                    await meshwiki_client.transition_task(subtask["wiki_page"], "failed")
+                except Exception as transition_exc:
+                    logger.warning(
+                        "pm_review: failed to transition %s to failed: %s",
+                        subtask["wiki_page"],
+                        transition_exc,
+                    )
+                continue
+
+            decision: str = result.get("decision", "changes_requested")
+            feedback: str | None = result.get("feedback")
+            total_incremental_cost += result.get("incremental_cost_usd", 0.0)
+
+            if decision == "approved":
+                if get_settings().auto_merge and subtask.get("pr_url"):
+                    pr_number = subtask.get("pr_number") or _extract_pr_number(
+                        subtask["pr_url"]
+                    )
+                    if pr_number:
+                        try:
+                            await github_client.merge_pr(pr_number)
+                            logger.info(
+                                "pm_review: auto-merged PR #%d for subtask %s",
+                                pr_number,
+                                subtask["id"],
+                            )
+                            try:
+                                await meshwiki_client.transition_task(
+                                    subtask["wiki_page"], "merged"
+                                )
+                            except Exception as exc:
+                                logger.warning(
+                                    "pm_review: failed to transition %s to merged: %s",
+                                    subtask["wiki_page"],
+                                    exc,
+                                )
+                        except Exception as exc:
+                            logger.warning(
+                                "pm_review: auto-merge failed for PR #%d: %s",
+                                pr_number,
+                                exc,
+                            )
+                updated_subtask = SubTask(
+                    **{**subtask, "status": "merged", "review_feedback": feedback}
+                )
+                logger.info("pm_review: subtask %s approved", subtask["id"])
+            else:
+                updated_subtask = SubTask(
+                    **{
+                        **subtask,
+                        "status": "changes_requested",
+                        "review_feedback": feedback,
+                        "attempt": subtask.get("attempt", 0) + 1,
+                    }
+                )
+                logger.info(
+                    "pm_review: subtask %s changes_requested: %s",
+                    subtask["id"],
+                    feedback,
                 )
 
-    return {
-        "subtasks": updated_subtasks,
-        "incremental_costs_usd": [total_incremental_cost],
-    }
+            updated_subtasks.append(updated_subtask)
+
+            timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M")
+
+            if decision == "approved":
+                pm_section = (
+                    f"## PM Review — {timestamp}\n\n"
+                    f"✅ **Approved**\n\n"
+                    f"{feedback or 'Looks good.'}\n"
+                )
+            else:
+                pm_section = (
+                    f"## PM Review — {timestamp}\n\n"
+                    f"❌ **Changes requested**\n\n"
+                    f"{feedback or 'See comments above.'}\n"
+                )
+
+            fm_updates: dict | None = None
+            if decision != "approved":
+                fm_updates = {"rework_count": updated_subtask.get("attempt", 1)}
+            try:
+                await meshwiki_client.append_to_page(
+                    subtask["wiki_page"], pm_section, frontmatter_updates=fm_updates
+                )
+            except Exception as exc:
+                logger.warning("pm_review: failed to append review to wiki: %s", exc)
+
+            if decision != "approved":
+                try:
+                    await meshwiki_client.transition_task(
+                        subtask["wiki_page"], "in_progress"
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "pm_review: failed to transition %s back to in_progress: %s",
+                        subtask["wiki_page"],
+                        exc,
+                    )
+
+        return {
+            "subtasks": updated_subtasks,
+            "incremental_costs_usd": [total_incremental_cost],
+        }

--- a/orchestrator/factory/nodes/task_intake.py
+++ b/orchestrator/factory/nodes/task_intake.py
@@ -34,8 +34,8 @@ async def task_intake_node(state: FactoryState) -> dict:
     task_wiki_page: str = state.get("task_wiki_page", "")
     logger.info("task_intake: loading task %s", task_wiki_page)
 
-    meshwiki_client = MeshWikiClient()
-    page = await meshwiki_client.get_page(task_wiki_page)
+    async with MeshWikiClient() as meshwiki_client:
+        page = await meshwiki_client.get_page(task_wiki_page)
 
     if page is None:
         logger.error("task_intake: task page %s not found", task_wiki_page)

--- a/orchestrator/factory/state.py
+++ b/orchestrator/factory/state.py
@@ -77,7 +77,7 @@ class FactoryState(TypedDict):
     decomposition_approved: bool
 
     # Execution
-    active_grinders: dict[str, str]  # subtask_id -> grinder session id
+    active_grinders: list[str]  # subtask_ids currently running in a sandbox
     completed_subtask_ids: Annotated[list[str], _union_ids]
     failed_subtask_ids: Annotated[list[str], _union_ids]
 

--- a/orchestrator/factory/webhook_server.py
+++ b/orchestrator/factory/webhook_server.py
@@ -30,53 +30,58 @@ async def _resume_interrupted_tasks(graph, saver, settings) -> None:
     3. If yes, call ainvoke(None) with the same thread_id — LangGraph resumes
        from the last node boundary rather than restarting from scratch.
     """
-    client = MeshWikiClient(settings.meshwiki_url, settings.meshwiki_api_key)
-    all_factory_tasks: list[dict] = []
-    for status in ("in_progress", "review"):
-        try:
-            tasks = await client.list_tasks(status=status)
-        except Exception as exc:
-            logger.warning(
-                "factory: could not fetch %s tasks on startup: %s", status, exc
+    async with MeshWikiClient(
+        settings.meshwiki_url, settings.meshwiki_api_key
+    ) as client:
+        all_factory_tasks: list[dict] = []
+        for status in ("in_progress", "review"):
+            try:
+                tasks = await client.list_tasks(status=status)
+            except Exception as exc:
+                logger.warning(
+                    "factory: could not fetch %s tasks on startup: %s", status, exc
+                )
+                continue
+            all_factory_tasks.extend(
+                t
+                for t in tasks
+                if t.get("metadata", {}).get("assignee") == "factory"
+                or t.get("assignee") == "factory"  # flat format (defensive)
             )
-            continue
-        all_factory_tasks.extend(
-            t
-            for t in tasks
-            if t.get("metadata", {}).get("assignee") == "factory"
-            or t.get("assignee") == "factory"  # flat format (defensive)
+
+        if not all_factory_tasks:
+            return
+
+        factory_tasks = all_factory_tasks
+        logger.info(
+            "factory: found %d active factory task(s) on startup", len(factory_tasks)
         )
+        for task in factory_tasks:
+            page_name = task.get("name", "")
+            if not page_name:
+                continue
 
-    if not all_factory_tasks:
-        return
+            config = {"configurable": {"thread_id": page_name}}
+            checkpoint_tuple = await saver.aget_tuple(config)
+            if checkpoint_tuple is None:
+                logger.info(
+                    "factory: no checkpoint for %s — skipping resume", page_name
+                )
+                continue
 
-    factory_tasks = all_factory_tasks
-    logger.info(
-        "factory: found %d active factory task(s) on startup", len(factory_tasks)
-    )
-    for task in factory_tasks:
-        page_name = task.get("name", "")
-        if not page_name:
-            continue
+            logger.info(
+                "factory: resuming interrupted task %s from checkpoint", page_name
+            )
 
-        config = {"configurable": {"thread_id": page_name}}
-        # Check whether a checkpoint exists for this thread.
-        checkpoint_tuple = await saver.aget_tuple(config)
-        if checkpoint_tuple is None:
-            logger.info("factory: no checkpoint for %s — skipping resume", page_name)
-            continue
+            def _log_exc(t: asyncio.Task, name: str = page_name) -> None:
+                if not t.cancelled() and (exc := t.exception()):
+                    logger.error("graph task %s failed: %s", name, exc, exc_info=exc)
 
-        logger.info("factory: resuming interrupted task %s from checkpoint", page_name)
-
-        def _log_exc(t: asyncio.Task, name: str = page_name) -> None:
-            if not t.cancelled() and (exc := t.exception()):
-                logger.error("graph task %s failed: %s", name, exc, exc_info=exc)
-
-        resume_task = asyncio.create_task(
-            graph.ainvoke(None, config=config),
-            name=f"graph:{page_name}:resume",
-        )
-        resume_task.add_done_callback(_log_exc)
+            resume_task = asyncio.create_task(
+                graph.ainvoke(None, config=config),
+                name=f"graph:{page_name}:resume",
+            )
+            resume_task.add_done_callback(_log_exc)
 
 
 @asynccontextmanager

--- a/orchestrator/tests/test_concurrency.py
+++ b/orchestrator/tests/test_concurrency.py
@@ -1,0 +1,172 @@
+"""Tests for grinder fan-out concurrency limiting."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from factory.nodes.assign import route_grinders
+from factory.state import FactoryState, SubTask
+
+
+def _make_subtask(
+    subtask_id: str, status: str = "pending", files: list[str] | None = None
+) -> SubTask:
+    """Return a minimal SubTask for testing."""
+    if files is None:
+        files = [f"src/{subtask_id}.py"]
+    return SubTask(
+        id=subtask_id,
+        wiki_page=f"{subtask_id}_page",
+        title=f"Subtask {subtask_id}",
+        description="Do the thing.",
+        status=status,
+        assigned_grinder=None,
+        branch_name=None,
+        pr_url=None,
+        pr_number=None,
+        attempt=0,
+        max_attempts=3,
+        error_log=[],
+        files_touched=files,
+        token_budget=50000,
+        tokens_used=0,
+        review_feedback=None,
+        code_skeleton=None,
+    )
+
+
+def _make_state(
+    pending_ids: list[str],
+    active_ids: list[str],
+) -> FactoryState:
+    """Build a FactoryState with given pending and active subtask IDs."""
+    subtasks = [_make_subtask(sid, "pending") for sid in pending_ids]
+    subtasks += [_make_subtask(sid, "running") for sid in active_ids]
+    return FactoryState(
+        thread_id="task-0042",
+        task_wiki_page="Task_0042_test",
+        title="Test Task",
+        requirements="Build something.",
+        subtasks=subtasks,
+        decomposition_approved=True,
+        active_grinders=active_ids,
+        completed_subtask_ids=[],
+        failed_subtask_ids=[],
+        pm_messages=[],
+        human_approval_response=None,
+        human_feedback=None,
+        cost_usd=0.0,
+        graph_status="grinding",
+        error=None,
+        escalation_decision=None,
+    )
+
+
+class TestRouteGrindersConcurrencyCap:
+    """route_grinders respects FACTORY_MAX_CONCURRENT_SANDBOXES cap."""
+
+    def test_cap_limits_dispatch_to_one(self) -> None:
+        """With cap=1, route_grinders dispatches only one subtask even when three are pending."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 1):
+            state = _make_state(["t1", "t2", "t3"], [])
+            dispatched = route_grinders(state)
+            assert len(dispatched) == 1
+
+    def test_no_dispatch_when_at_cap(self) -> None:
+        """With cap=1 and one active grinder, no new dispatch occurs."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 1):
+            state = _make_state(["t2", "t3"], ["t1"])
+            dispatched = route_grinders(state)
+            assert dispatched == []
+
+    def test_partial_dispatch_with_two_slots_free(self) -> None:
+        """With cap=3 and one active, two pending subtasks get dispatched (no file conflicts)."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 3):
+            state = _make_state(["t1", "t2", "t3"], ["active-1"])
+            dispatched = route_grinders(state)
+            assert len(dispatched) == 2
+
+    def test_all_pending_dispatched_when_under_cap(self) -> None:
+        """When pending < available slots and no conflicts, all pending get dispatched."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 5):
+            state = _make_state(["t1", "t2"], [])
+            dispatched = route_grinders(state)
+            assert len(dispatched) == 2
+
+    def test_excludes_already_active_from_pending(self) -> None:
+        """Subtasks already in active_grinders are not dispatched again."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 3):
+            state = _make_state(["t1", "t2", "t3"], ["t1"])
+            dispatched = route_grinders(state)
+            dispatched_ids = [s.arg["_current_subtask_id"] for s in dispatched]
+            assert "t1" not in dispatched_ids
+
+    def test_returns_empty_when_no_pending(self) -> None:
+        """No dispatch when all subtasks are already running."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 3):
+            state = _make_state([], ["t1", "t2", "t3"])
+            dispatched = route_grinders(state)
+            assert dispatched == []
+
+    def test_file_conflict_serializes_within_cap(self) -> None:
+        """File conflicts serialize even when cap would allow more."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 5):
+            subtasks = [
+                _make_subtask("t1", files=["src/shared.py"]),
+                _make_subtask("t2", files=["src/shared.py"]),
+            ]
+            state = FactoryState(
+                thread_id="task-0042",
+                task_wiki_page="Task_0042_test",
+                title="Test Task",
+                requirements="Build something.",
+                subtasks=subtasks,
+                decomposition_approved=True,
+                active_grinders=[],
+                completed_subtask_ids=[],
+                failed_subtask_ids=[],
+                pm_messages=[],
+                human_approval_response=None,
+                human_feedback=None,
+                cost_usd=0.0,
+                graph_status="grinding",
+                error=None,
+                escalation_decision=None,
+            )
+            dispatched = route_grinders(state)
+            assert len(dispatched) == 1
+
+    def test_dispatch_respects_cap_not_file_conflicts(self) -> None:
+        """When cap=1 and one pending, that one is dispatched regardless of conflicts."""
+        with patch("factory.nodes.assign.FACTORY_MAX_CONCURRENT_SANDBOXES", 1):
+            state = _make_state(["t1"], [])
+            dispatched = route_grinders(state)
+            assert len(dispatched) == 1
+
+
+class TestActiveGrindersCleanup:
+    """grind_node removes subtask id from active_grinders after completion."""
+
+    def test_active_grinders_removal_on_completion(self) -> None:
+        """Simulate grinder completion: subtask ID should be removable from active list."""
+        active = ["task-a", "task-b"]
+        active.remove("task-a")
+        assert active == ["task-b"]
+
+    def test_active_grinders_removal_idempotent(self) -> None:
+        """Removing a non-existent ID should not raise."""
+        active = ["task-a"]
+        if "task-b" in active:
+            active.remove("task-b")
+        assert active == ["task-a"]
+
+    def test_active_grinders_list_behavior(self) -> None:
+        """active_grinders should behave as a simple list of IDs."""
+        active: list[str] = []
+        active.append("t1")
+        active.append("t2")
+        assert len(active) == 2
+        active.remove("t1")
+        assert len(active) == 1
+        assert "t1" not in active
+        assert "t2" in active

--- a/orchestrator/tests/test_http_clients.py
+++ b/orchestrator/tests/test_http_clients.py
@@ -1,0 +1,74 @@
+"""Tests verifying that MeshWikiClient and GitHubClient share a single httpx.AsyncClient."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.integrations.github_client import GitHubClient
+from factory.integrations.meshwiki_client import MeshWikiClient
+
+
+class TestMeshWikiClientSharedClient:
+    def test_creates_one_async_client(self) -> None:
+        """MeshWikiClient.__init__ must create exactly one httpx.AsyncClient."""
+        with patch(
+            "factory.integrations.meshwiki_client.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _ = MeshWikiClient(base_url="http://localhost", api_key="tok")
+            assert mock_cls.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_close_calls_aclose(self) -> None:
+        """close() must call aclose() on the underlying AsyncClient."""
+        with patch(
+            "factory.integrations.meshwiki_client.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            client = MeshWikiClient(base_url="http://localhost", api_key="tok")
+            await client.close()
+            mock_instance.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_calls_aclose_on_exit(self) -> None:
+        """Exiting async with must call aclose() on the underlying AsyncClient."""
+        with patch(
+            "factory.integrations.meshwiki_client.httpx.AsyncClient"
+        ) as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            async with MeshWikiClient(base_url="http://localhost", api_key="tok"):
+                pass
+            mock_instance.aclose.assert_awaited_once()
+
+
+class TestGitHubClientSharedClient:
+    def test_creates_one_async_client(self) -> None:
+        """GitHubClient.__init__ must create exactly one httpx.AsyncClient."""
+        with patch("factory.integrations.github_client.httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _ = GitHubClient(token="tok", repo="owner/repo")
+            assert mock_cls.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_close_calls_aclose(self) -> None:
+        """close() must call aclose() on the underlying AsyncClient."""
+        with patch("factory.integrations.github_client.httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            client = GitHubClient(token="tok", repo="owner/repo")
+            await client.close()
+            mock_instance.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_calls_aclose_on_exit(self) -> None:
+        """Exiting async with must call aclose() on the underlying AsyncClient."""
+        with patch("factory.integrations.github_client.httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_cls.return_value = mock_instance
+            async with GitHubClient(token="tok", repo="owner/repo"):
+                pass
+            mock_instance.aclose.assert_awaited_once()

--- a/orchestrator/tests/test_nodes.py
+++ b/orchestrator/tests/test_nodes.py
@@ -62,6 +62,20 @@ def _make_subtask(**kwargs) -> SubTask:
     return subtask
 
 
+def _mock_client_for_cm(mock_client: AsyncMock) -> AsyncMock:
+    """Configure an AsyncMock to work as a context manager returning itself.
+
+    When MeshWikiClient/GitHubClient is patched with return_value=mock_client,
+    the code calls `async with mock_client as cm`.  By default AsyncMock's
+    __aenter__ returns a new AsyncMock (not mock_client), so method calls go
+    to the wrong object.  This helper fixes __aenter__ / __aexit__ so that
+    `cm is mock_client`.
+    """
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return mock_client
+
+
 # ---------------------------------------------------------------------------
 # task_intake_node
 # ---------------------------------------------------------------------------
@@ -75,10 +89,14 @@ async def test_task_intake_node() -> None:
     mock_page = {
         "name": "Task_0042_test",
         "content": "## Requirements\nBuild the feature.",
-        "metadata": {"title": "Test Task Title", "status": "planned"},
+        "metadata": {
+            "title": "Test Task Title",
+            "status": "planned",
+            "assignee": "factory",
+        },
     }
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=mock_page)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -95,7 +113,7 @@ async def test_task_intake_node_page_not_found() -> None:
     """task_intake_node falls back gracefully when the page is not found."""
     state = _make_state()
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=None)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -125,7 +143,7 @@ async def test_decompose_node() -> None:
         title="Build something",
     )
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.create_page = AsyncMock(return_value={})
     mock_meshwiki.transition_task = AsyncMock(return_value={})
 
@@ -149,10 +167,9 @@ async def test_decompose_node() -> None:
     create_args = mock_meshwiki.create_page.call_args
     assert create_args[0][0] == "Task_0042_Sub_01_build"
 
-    # Should have transitioned subtask to planned and parent to decomposed
-    assert mock_meshwiki.transition_task.await_count == 2
+    # Should have transitioned the parent task to decomposed
+    assert mock_meshwiki.transition_task.await_count == 1
     calls = [c[0] for c in mock_meshwiki.transition_task.call_args_list]
-    assert ("Task_0042_Sub_01_build", "planned") in calls
     assert ("Task_0042_test", "decomposed") in calls
 
 
@@ -161,7 +178,7 @@ async def test_decompose_node_no_subtasks() -> None:
     """decompose_node handles empty subtask list from PM agent."""
     state = _make_state()
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.create_page = AsyncMock(return_value={})
     mock_meshwiki.transition_task = AsyncMock(return_value={})
 
@@ -199,10 +216,10 @@ async def test_pm_review_node_approved() -> None:
     )
     state = _make_state(subtasks=[review_subtask])
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.get_page = AsyncMock(return_value={"content": "criteria"})
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr_diff = AsyncMock(return_value="diff content")
 
     with (
@@ -231,10 +248,10 @@ async def test_pm_review_node_changes_requested() -> None:
     )
     state = _make_state(subtasks=[review_subtask])
 
-    mock_meshwiki = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
     mock_meshwiki.get_page = AsyncMock(return_value=None)
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
 
     with (
         patch("factory.nodes.pm_review.MeshWikiClient", return_value=mock_meshwiki),
@@ -265,8 +282,8 @@ async def test_pm_review_node_skips_non_review_subtasks() -> None:
     )
     state = _make_state(subtasks=[pending_subtask])
 
-    mock_meshwiki = AsyncMock()
-    mock_github = AsyncMock()
+    mock_meshwiki = _mock_client_for_cm(AsyncMock())
+    mock_github = _mock_client_for_cm(AsyncMock())
 
     with (
         patch("factory.nodes.pm_review.MeshWikiClient", return_value=mock_meshwiki),
@@ -333,12 +350,13 @@ async def test_task_intake_direct_grind() -> None:
             "title": "Direct Grind Task",
             "status": "planned",
             "skip_decomposition": "true",
+            "assignee": "factory",
             "expected_files": ["src/meshwiki/main.py"],
             "token_budget": "30000",
         },
     }
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=mock_page)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -379,10 +397,11 @@ async def test_task_intake_direct_grind_boolean_flag() -> None:
             "title": "Bool Flag Task",
             "status": "planned",
             "skip_decomposition": True,
+            "assignee": "factory",
         },
     }
 
-    mock_client = AsyncMock()
+    mock_client = _mock_client_for_cm(AsyncMock())
     mock_client.get_page = AsyncMock(return_value=mock_page)
 
     with patch("factory.nodes.task_intake.MeshWikiClient", return_value=mock_client):
@@ -449,7 +468,7 @@ async def test_finalize_node() -> None:
     """finalize_node calls transition_task with 'done' and returns completed status."""
     state = _make_state(cost_usd=0.0042)
 
-    mock_client_instance = AsyncMock()
+    mock_client_instance = _mock_client_for_cm(AsyncMock())
     mock_client_instance.transition_task = AsyncMock(return_value={})
     mock_client_cls = MagicMock(return_value=mock_client_instance)
 
@@ -469,7 +488,7 @@ async def test_finalize_node_handles_client_error() -> None:
     """finalize_node logs and swallows MeshWiki client errors, still returns completed."""
     state = _make_state()
 
-    mock_client_instance = AsyncMock()
+    mock_client_instance = _mock_client_for_cm(AsyncMock())
     mock_client_instance.transition_task = AsyncMock(
         side_effect=RuntimeError("network error")
     )
@@ -562,7 +581,7 @@ async def test_merge_check_node_merged_pr() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 10, "state": "closed", "merged": True}
     )
@@ -585,7 +604,7 @@ async def test_merge_check_node_closed_not_merged() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 11, "state": "closed", "merged": False}
     )
@@ -607,7 +626,7 @@ async def test_merge_check_node_still_open() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 12, "state": "open", "merged": False}
     )
@@ -630,7 +649,7 @@ async def test_merge_check_node_pr_number_from_url() -> None:
     review_sub["pr_url"] = "https://github.com/owner/repo/pull/42"
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         return_value={"number": 42, "state": "closed", "merged": True}
     )
@@ -694,7 +713,7 @@ async def test_merge_check_node_api_error_continues() -> None:
     )
     state = _make_state(subtasks=[review_sub])
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(
         side_effect=httpx.HTTPStatusError(
             "404 Not Found",
@@ -737,7 +756,7 @@ async def test_merge_check_node_multiple_subtasks() -> None:
             return {"number": 20, "state": "closed", "merged": True}
         return {"number": 21, "state": "open", "merged": False}
 
-    mock_github = AsyncMock()
+    mock_github = _mock_client_for_cm(AsyncMock())
     mock_github.get_pr = AsyncMock(side_effect=_fake_get_pr)
 
     with patch("factory.nodes.merge_check.GitHubClient", return_value=mock_github):


### PR DESCRIPTION
## Summary

Merges TASK002 and TASK003 from Epic_0001 (Factory v2 Gap Fixes). PRs #131 and #133 had conflicts with the already-merged #132 (cost tracking), so this resolves both onto current staging.

- **TASK002** (PR #133): `FACTORY_MAX_CONCURRENT_SANDBOXES` cap in `assign.py`/`grind.py`, `active_grinders` tracking, 11 new concurrency tests
- **TASK003** (PR #131): `MeshWikiClient` and `GitHubClient` each use a single shared `httpx.AsyncClient` via `async with` context manager, new `test_http_clients.py`

Conflict resolved in `grind.py` — combined TASK002's `active_grinders` list tracking with TASK003's context manager pattern.

Closes #131, Closes #133