### PR TITLE
[Factory] Add /api/pages/{page_name}/preview endpoint

### DIFF
--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -59,6 +59,7 @@ from meshwiki.core.storage import FileStorage
 from meshwiki.core.task_machine import TASK_TRANSITIONS
 from meshwiki.core.task_machine import transition_task as _machine_transition
 from meshwiki.core.ws_manager import manager
+from meshwiki.routes.api import router as api_preview_router
 
 # Configure structured logging before anything else
 configure_logging()
@@ -216,6 +217,8 @@ if settings.factory_enabled:
     from meshwiki.api import router as api_v1_router
 
     app.include_router(api_v1_router)
+
+app.include_router(api_preview_router, prefix="/api")
 
 
 # Template context helper

--- a/src/meshwiki/routes/api.py
+++ b/src/meshwiki/routes/api.py
@@ -1,0 +1,41 @@
+"""Public JSON API endpoints (hover cards, previews, search)."""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from meshwiki.core.dependencies import get_storage
+
+router = APIRouter()
+
+
+class PagePreview(BaseModel):
+    page_name: str
+    excerpt: str
+    exists: bool
+
+
+def _first_paragraph(body: str, max_len: int = 300) -> str:
+    """Return the first non-empty paragraph, plain-text, truncated."""
+    for chunk in body.split("\n\n"):
+        text = chunk.strip()
+        if text:
+            text = re.sub(r"<[^>]+>", "", text)
+            text = re.sub(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]", r"\1", text)
+            text = re.sub(r"[*_`#]", "", text)
+            return text[:max_len]
+    return ""
+
+
+@router.get("/pages/{page_name}/preview", response_model=PagePreview)
+async def page_preview(page_name: str) -> PagePreview:
+    """Return the first paragraph of a wiki page for hover card preview."""
+    storage = get_storage()
+    page = await storage.get_page(page_name)
+    if page is None:
+        return PagePreview(page_name=page_name, excerpt="", exists=False)
+    excerpt = _first_paragraph(page.content)
+    return PagePreview(page_name=page_name, excerpt=excerpt, exists=True)

--- a/src/tests/test_preview_endpoint.py
+++ b/src/tests/test_preview_endpoint.py
@@ -1,0 +1,71 @@
+"""Integration tests for GET /api/pages/{page_name}/preview."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import meshwiki.main
+
+
+@pytest.fixture
+async def client(tmp_path):
+    """Async HTTP client pointing at a fresh temp wiki."""
+    import meshwiki.config
+
+    meshwiki.config.settings.data_dir = tmp_path
+    meshwiki.config.settings.factory_enabled = False
+    meshwiki.config.settings.graph_watch = False
+    meshwiki.config.settings.auth_enabled = False
+
+    from meshwiki.core.graph import init_engine, shutdown_engine
+
+    init_engine(tmp_path, watch=False)
+    meshwiki.main.manager.start_polling()
+    async with AsyncClient(
+        transport=ASGITransport(app=meshwiki.main.app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as c:
+        yield c
+    meshwiki.main.manager.stop_polling()
+    shutdown_engine()
+
+
+@pytest.mark.asyncio
+async def test_preview_existing_page(client):
+    """Returns exists:true and a non-empty excerpt for an existing page."""
+    await client.post(
+        "/page/TestPage",
+        data={
+            "content": "# Hello\n\nThis is the first paragraph.\n\nAnd this is the second."
+        },
+    )
+    resp = await client.get("/api/pages/TestPage/preview")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["exists"] is True
+    assert body["page_name"] == "TestPage"
+    assert body["excerpt"]
+    assert len(body["excerpt"]) <= 300
+
+
+@pytest.mark.asyncio
+async def test_preview_missing_page(client):
+    """Returns exists:false and empty excerpt for a missing page."""
+    resp = await client.get("/api/pages/NonExistentPage/preview")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["exists"] is False
+    assert body["page_name"] == "NonExistentPage"
+    assert body["excerpt"] == ""
+
+
+@pytest.mark.asyncio
+async def test_preview_excerpt_truncated_at_300(client):
+    """Excerpt is truncated to 300 characters."""
+    long_content = "# Title\n\n" + ("x" * 400)
+    await client.post("/page/LongPage", data={"content": long_content})
+    resp = await client.get("/api/pages/LongPage/preview")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["exists"] is True
+    assert len(body["excerpt"]) <= 300


### PR DESCRIPTION
## Summary
- Add `GET /api/pages/{page_name}/preview` endpoint returning first paragraph for hover cards
- Returns `PagePreview` model with `page_name`, `excerpt` (≤300 chars, plain text), and `exists` fields
- Returns HTTP 200 with `exists: false` for missing pages (not 404) so hover cards handle gracefully
- Registered under `/api` prefix in `app.py`

## Tests
- `test_preview_existing_page`: exists:true, non-empty excerpt, ≤300 chars
- `test_preview_missing_page`: exists:false, empty excerpt
- `test_preview_excerpt_truncated_at_300`: excerpt capped at 300 characters

## Files
- `src/meshwiki/routes/api.py` - new router with `PagePreview` model and `page_preview` handler
- `src/meshwiki/main.py` - imports and registers the router
- `src/tests/test_preview_endpoint.py` - integration tests