### PR TITLE
[Factory] Add hover card Jinja2 partial template and CSS styles

### DIFF
--- a/src/meshwiki/static/css/hover_card.css
+++ b/src/meshwiki/static/css/hover_card.css
@@ -1,0 +1,17 @@
+.hover-card {
+    position: fixed;
+    z-index: 9999;
+    max-width: 320px;
+    padding: 0.75rem 1rem;
+    background: var(--color-surface, #fff);
+    border: 1px solid var(--color-border, #ddd);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0,0,0,.15);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    pointer-events: none;
+    display: none;
+}
+.hover-card__title   { font-weight: 600; margin: 0 0 .25rem; }
+.hover-card__excerpt { margin: 0; color: var(--color-text-secondary, #555); }
+.hover-card__not-found { margin: 0; color: var(--color-danger, #c00); }

--- a/src/meshwiki/templates/base.html
+++ b/src/meshwiki/templates/base.html
@@ -6,6 +6,7 @@
     <title>{% block title %}{{ app_title }}{% endblock %}</title>
     <script>(function(){var t=localStorage.getItem('meshwiki-theme');if(t)document.documentElement.setAttribute('data-theme',t);})()</script>
     <link rel="stylesheet" href="/static/css/style.css">
+    <link rel="stylesheet" href="/static/css/hover_card.css">
     <link id="hljs-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
     <script>(function(){var t=localStorage.getItem('meshwiki-theme');if(t==='dark'){var l=document.getElementById('hljs-theme');if(l)l.href='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css';}})()</script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>

--- a/src/meshwiki/templates/partials/hover_card.html
+++ b/src/meshwiki/templates/partials/hover_card.html
@@ -1,0 +1,8 @@
+<div id="wiki-hover-card" class="hover-card" role="tooltip">
+  {% if exists %}
+    <p class="hover-card__title">{{ page_name | replace("_", " ") }}</p>
+    <p class="hover-card__excerpt">{{ excerpt }}</p>
+  {% else %}
+    <p class="hover-card__not-found">⚠ Page not found</p>
+  {% endif %}
+</div>

--- a/src/tests/test_hover_card_template.py
+++ b/src/tests/test_hover_card_template.py
@@ -1,0 +1,40 @@
+from jinja2 import Environment
+
+
+def render_hover_card(**context):
+    import os
+
+    env = Environment(autoescape=False)
+    tpl_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "meshwiki",
+        "templates",
+        "partials",
+        "hover_card.html",
+    )
+    with open(tpl_path) as f:
+        tpl = env.from_string(f.read())
+    return tpl.render(**context)
+
+
+def test_hover_card_has_id():
+    result = render_hover_card(
+        exists=True, page_name="Test_Page", excerpt="Test excerpt"
+    )
+    assert 'id="wiki-hover-card"' in result
+
+
+def test_hover_card_renders_excerpt_when_exists():
+    result = render_hover_card(
+        exists=True, page_name="Test_Page", excerpt="Test excerpt"
+    )
+    assert "Test excerpt" in result
+    assert "Test Page" in result
+
+
+def test_hover_card_renders_not_found_when_not_exists():
+    result = render_hover_card(
+        exists=False, page_name="Test_Page", excerpt="Test excerpt"
+    )
+    assert "Page not found" in result


### PR DESCRIPTION
## Summary
- Add `templates/partials/hover_card.html` with `id="wiki-hover-card"` and class `hover-card`
- Add `static/css/hover_card.css` with fixed positioning, z-index 9999, display:none, pointer-events:none
- Link hover_card.css in base.html `<head>`
- Add `tests/test_hover_card_template.py` with 3 tests covering exists/not-found states

## Tests
- All 3 hover card tests pass
- Full test suite (674 tests) passes with the new tests