### PR TITLE
[Factory] Wire hover card with HTMX and vanilla JS

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -93,6 +93,13 @@ class WikiLinkInlineProcessor(InlineProcessor):
         el = Element("a")
         el.text = display_text
         el.set("href", f"/page/{page_name.replace(' ', '_')}")
+        el.set(
+            "hx-get",
+            f"/api/pages/{page_name.replace(' ', '_')}/preview",
+        )
+        el.set("hx-trigger", "mouseenter delay:250ms")
+        el.set("hx-target", "#wiki-hover-card")
+        el.set("hx-swap", "outerHTML")
 
         # Add class based on whether page exists
         if self.page_exists(page_name):

--- a/src/meshwiki/main.py
+++ b/src/meshwiki/main.py
@@ -807,6 +807,15 @@ async def save_page(request: Request, name: str, content: str = Form("")):
 # ========== Editor API ==========
 
 
+@app.get("/api/pages/{name:path}/preview", response_class=HTMLResponse)
+async def api_page_preview(name: str):
+    """Render a page for hover card preview."""
+    page = await storage.get_page(name)
+    if page is None:
+        return HTMLResponse("")
+    return HTMLResponse(page.content)
+
+
 @app.post("/api/preview", response_class=HTMLResponse)
 async def api_preview(content: str = Form("")):
     """Render markdown preview for the editor."""

--- a/src/meshwiki/static/js/hover_card.js
+++ b/src/meshwiki/static/js/hover_card.js
@@ -1,0 +1,23 @@
+(function() {
+    var card = document.getElementById('wiki-hover-card');
+    if (!card) return;
+
+    var closeTimer;
+
+    document.addEventListener('mousemove', function(e) {
+        card.style.position = 'fixed';
+        card.style.left = (e.clientX + 15) + 'px';
+        card.style.top = (e.clientY + 10) + 'px';
+    });
+
+    card.addEventListener('mouseleave', function() {
+        card.style.display = 'none';
+        clearTimeout(closeTimer);
+    });
+
+    document.body.addEventListener('htmx:afterSwap', function(e) {
+        if (e.target.id === 'wiki-hover-card') {
+            card.style.display = 'block';
+        }
+    });
+})();

--- a/src/meshwiki/templates/base.html
+++ b/src/meshwiki/templates/base.html
@@ -10,6 +10,7 @@
     <script>(function(){var t=localStorage.getItem('meshwiki-theme');if(t==='dark'){var l=document.getElementById('hljs-theme');if(l)l.href='https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css';}})()</script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="/static/js/hover_card.js"></script>
 </head>
 <body>
     {% macro render_tree(nodes, level=0) %}
@@ -223,5 +224,6 @@
     </script>
     {% block extra_css %}{% endblock %}
     {% block extra_scripts %}{% endblock %}
+    <div id="wiki-hover-card" class="hover-card" style="display:none"></div>
 </body>
 </html>

--- a/src/tests/test_hover_card_js.py
+++ b/src/tests/test_hover_card_js.py
@@ -1,0 +1,93 @@
+"""Tests for hover card HTMX wiring and wiki link attributes."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import meshwiki.main
+from meshwiki.core.parser import parse_wiki_content
+
+
+@pytest.fixture(autouse=True)
+def _patch_storage(tmp_path):
+    original = meshwiki.main.storage.base_path
+    meshwiki.main.storage.base_path = tmp_path
+    yield
+    meshwiki.main.storage.base_path = original
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=meshwiki.main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ============================================================
+# Wiki link HTMX attributes
+# ============================================================
+
+
+class TestWikiLinkHtmxAttrs:
+    def test_wiki_link_has_hx_get(self):
+        html = parse_wiki_content("[[TestPage]]", page_exists=lambda x: True)
+        assert 'hx-get="/api/pages/TestPage/preview"' in html
+
+    def test_wiki_link_has_hx_trigger(self):
+        html = parse_wiki_content("[[TestPage]]", page_exists=lambda x: True)
+        assert 'hx-trigger="mouseenter delay:250ms"' in html
+
+    def test_wiki_link_has_hx_target(self):
+        html = parse_wiki_content("[[TestPage]]", page_exists=lambda x: True)
+        assert 'hx-target="#wiki-hover-card"' in html
+
+    def test_wiki_link_has_hx_swap(self):
+        html = parse_wiki_content("[[TestPage]]", page_exists=lambda x: True)
+        assert 'hx-swap="outerHTML"' in html
+
+    def test_wiki_link_all_htmx_attrs_present(self):
+        html = parse_wiki_content("[[TestPage]]", page_exists=lambda x: True)
+        assert 'hx-get="/api/pages/TestPage/preview"' in html
+        assert 'hx-trigger="mouseenter delay:250ms"' in html
+        assert 'hx-target="#wiki-hover-card"' in html
+        assert 'hx-swap="outerHTML"' in html
+
+    def test_wiki_link_with_spaces_has_correct_hx_get(self):
+        html = parse_wiki_content("[[My Test Page]]", page_exists=lambda x: True)
+        assert 'hx-get="/api/pages/My_Test_Page/preview"' in html
+
+    def test_missing_page_link_has_htmx_attrs(self):
+        html = parse_wiki_content("[[MissingPage]]", page_exists=lambda x: False)
+        assert 'hx-get="/api/pages/MissingPage/preview"' in html
+        assert 'hx-trigger="mouseenter delay:250ms"' in html
+
+
+# ============================================================
+# Page preview API endpoint
+# ============================================================
+
+
+class TestPagePreviewEndpoint:
+    @pytest.mark.asyncio
+    async def test_preview_endpoint_returns_page_content(self, client):
+        await meshwiki.main.storage.save_page("HoverTest", "# Test Content")
+        resp = await client.get("/api/pages/HoverTest/preview")
+        assert resp.status_code == 200
+        assert "# Test Content" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_preview_endpoint_missing_page_returns_empty(self, client):
+        resp = await client.get("/api/pages/NonExistentPage/preview")
+        assert resp.status_code == 200
+        assert resp.text == ""
+
+    @pytest.mark.asyncio
+    async def test_preview_endpoint_with_frontmatter(self, client):
+        content = """---
+title: Test Page
+---
+# Hello World
+"""
+        await meshwiki.main.storage.save_page("FrontmatterPage", content)
+        resp = await client.get("/api/pages/FrontmatterPage/preview")
+        assert resp.status_code == 200
+        assert "# Hello World" in resp.text


### PR DESCRIPTION
## Summary
- Add HTMX attributes (hx-get, hx-trigger, hx-target, hx-swap) to wiki link a elements in WikiLinkInlineProcessor
- Add GET /api/pages/{name}/preview endpoint for hover card content
- Create hover_card.js with mousemove positioning and htmx:afterSwap show logic
- Add hover card placeholder div and script include to base.html
- Add test_hover_card_js.py with parser and API tests

## Testing
- 687 tests pass (32 skipped)