### PR TITLE
[Factory] RunningClock macro backend (parser + registration)

### DIFF
--- a/src/meshwiki/core/parser.py
+++ b/src/meshwiki/core/parser.py
@@ -14,6 +14,7 @@ from markdown.inlinepatterns import InlineProcessor, SimpleTagInlineProcessor
 from markdown.preprocessors import Preprocessor
 
 from meshwiki.core.graph import get_engine
+from meshwiki.extensions.running_clock import RunningClockExtension
 
 _ESCAPED_MACRO_RE = re.compile(r"\\<<([A-Za-z][^>]*)>>")
 
@@ -1878,6 +1879,7 @@ def create_parser(
             CalloutExtension(),  # ```info``` etc. callout blocks
             RecentChangesExtension(recent_pages=recent_pages),  # <<RecentChanges(n)>>
             PageCountExtension(),  # <<PageCount>>
+            RunningClockExtension(),  # <<RunningClock>>
             TagListExtension(pages=pages),  # <<TagList>>
             BackLinksExtension(page_name=page_name),  # <<BackLinks>>
             ChildrenExtension(page_metadata=page_metadata),  # <<Children>>

--- a/src/meshwiki/extensions/running_clock.py
+++ b/src/meshwiki/extensions/running_clock.py
@@ -1,0 +1,70 @@
+"""RunningClock macro — renders an HTML shell for the JS clock widget.
+
+Usage in wiki markup:
+    <<RunningClock>>
+    <<RunningClock timezone="Europe/London">>
+"""
+
+from __future__ import annotations
+
+import re
+import zoneinfo
+from typing import TYPE_CHECKING
+
+from markdown import Markdown
+from markdown.extensions import Extension
+from markdown.preprocessors import Preprocessor
+
+if TYPE_CHECKING:
+    pass
+
+_MACRO_RE = re.compile(r"<<RunningClock(?:\s+timezone=\"([^\"]+)\")?\s*>>")
+
+
+class RunningClockPreprocessor(Preprocessor):
+    """Replace <<RunningClock …>> tokens with the clock HTML shell."""
+
+    def run(self, lines: list[str]) -> list[str]:
+        text = "\n".join(lines)
+        if "<<RunningClock" not in text:
+            return lines
+
+        code_block_re = re.compile(r"(```.*?```|~~~.*?~~~)", re.DOTALL)
+        code_blocks: list[str] = []
+
+        def stash_code(m: re.Match[str]) -> str:
+            placeholder = f"\x00RCBLOCK{len(code_blocks)}\x00"
+            code_blocks.append(m.group(0))
+            return placeholder
+
+        text = code_block_re.sub(stash_code, text)
+
+        def replace_match(m: re.Match[str]) -> str:
+            tz_name: str = m.group(1) or "UTC"
+            try:
+                zoneinfo.ZoneInfo(tz_name)
+            except (zoneinfo.ZoneInfoNotFoundError, KeyError):
+                return f'<span class="macro-error">Unknown timezone: {tz_name}</span>'
+            return f'<span class="running-clock" data-clock data-timezone="{tz_name}"></span>'
+
+        text = _MACRO_RE.sub(replace_match, text)
+
+        for i, block in enumerate(code_blocks):
+            text = text.replace(f"\x00RCBLOCK{i}\x00", block)
+
+        return text.split("\n")
+
+
+class RunningClockExtension(Extension):
+    """Markdown extension that registers the RunningClock preprocessor."""
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.preprocessors.register(
+            RunningClockPreprocessor(md),
+            "running_clock",
+            29,
+        )
+
+
+def makeExtension(**kwargs: object) -> RunningClockExtension:
+    return RunningClockExtension(**kwargs)

--- a/src/tests/test_running_clock_extension.py
+++ b/src/tests/test_running_clock_extension.py
@@ -1,0 +1,54 @@
+"""Unit tests for the RunningClock macro."""
+
+from meshwiki.core.parser import parse_wiki_content
+
+
+class TestRunningClockMacro:
+    def test_running_clock_default_timezone(self):
+        """<<RunningClock>> renders data-timezone="UTC"."""
+        html = parse_wiki_content("<<RunningClock>>")
+        assert 'data-timezone="UTC"' in html
+
+    def test_running_clock_paris_timezone(self):
+        """<<RunningClock timezone="Europe/Paris">> renders the correct timezone."""
+        html = parse_wiki_content('<<RunningClock timezone="Europe/Paris">>')
+        assert 'data-timezone="Europe/Paris"' in html
+
+    def test_running_clock_invalid_timezone(self):
+        """Invalid timezone renders .macro-error span."""
+        html = parse_wiki_content('<<RunningClock timezone="Mars/Olympus">>')
+        assert "macro-error" in html
+        assert "Mars/Olympus" in html
+        assert "running-clock" not in html
+
+    def test_running_clock_has_required_attributes(self):
+        """Rendered HTML contains the running-clock class and data-clock attribute."""
+        html = parse_wiki_content("<<RunningClock>>")
+        assert 'class="running-clock"' in html
+        assert "data-clock" in html
+
+    def test_running_clock_in_paragraph(self):
+        """Macro works when embedded in a paragraph."""
+        html = parse_wiki_content("The time is: <<RunningClock>> right now.")
+        assert 'data-timezone="UTC"' in html
+
+    def test_running_clock_not_in_code_block(self):
+        """Macro inside ``` should be literal text."""
+        content = "```\n<<RunningClock>>\n```"
+        html = parse_wiki_content(content)
+        assert "running-clock" not in html
+        assert "data-clock" not in html
+
+    def test_running_clock_not_in_tilde_code(self):
+        """Macro inside ~~~ should be literal text."""
+        content = "~~~\n<<RunningClock>>\n~~~"
+        html = parse_wiki_content(content)
+        assert "running-clock" not in html
+        assert "data-clock" not in html
+
+    def test_running_clock_new_york_timezone(self):
+        """<<RunningClock timezone="America/New_York">> renders correctly."""
+        html = parse_wiki_content('<<RunningClock timezone="America/New_York">>')
+        assert 'data-timezone="America/New_York"' in html
+        assert 'class="running-clock"' in html
+        assert "data-clock" in html


### PR DESCRIPTION
## Summary
- Add `RunningClockExtension` and `RunningClockPreprocessor` in `src/meshwiki/extensions/running_clock.py`
- Supports `<<RunningClock>>` (defaults to UTC) and `<<RunningClock timezone=\"Europe/Paris\">>` syntax
- Validates IANA timezone strings via `zoneinfo.ZoneInfo`; renders `.macro-error` span on invalid TZ
- Renders `<span class=\"running-clock\" data-clock data-timezone=\"{tz}\"></span>` for valid timezones
- Registered in `parser.py` `create_parser()` alongside other extensions
- No `asyncio.run()` calls; full type hints; PEP 8 compliant

## Acceptance Criteria
- [x] `<<RunningClock>>` renders `data-timezone=\"UTC\"`
- [x] `<<RunningClock timezone=\"America/New_York\">>` renders `data-timezone=\"America/New_York\"`
- [x] Invalid timezone renders `.macro-error` span
- [x] `RunningClockExtension` registered in parser.py
- [x] All 8 unit tests pass
- [x] No `asyncio.run()` calls
- [x] Full type hints and PEP 8 compliance