### PR TITLE
[Factory] Sidebar status badges for Factory nodes

### DIFF
--- a/src/meshwiki/static/css/style.css
+++ b/src/meshwiki/static/css/style.css
@@ -12,6 +12,8 @@
     --color-border: #e5e5e5;
     --color-danger: #dc3545;
     --color-danger-hover: #bb2d3b;
+    --color-warning: #f59e0b;
+    --color-success: #16a34a;
     --color-success-bg: #dcfce7;
     --color-success-text: #166534;
     --color-shadow: rgba(0, 0, 0, 0.1);
@@ -32,6 +34,8 @@
     --color-border: #3f3f46;
     --color-danger: #ef4444;
     --color-danger-hover: #dc2626;
+    --color-warning: #f59e0b;
+    --color-success: #16a34a;
     --color-success-bg: #064e3b;
     --color-success-text: #6ee7b7;
     --color-shadow: rgba(0, 0, 0, 0.4);
@@ -210,6 +214,44 @@ body {
     color: var(--color-text-muted);
     text-decoration: line-through;
     text-decoration-color: var(--color-border);
+}
+
+.task-status {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-left: 6px;
+    flex-shrink: 0;
+    vertical-align: middle;
+}
+
+.task-status--in_progress {
+    background: var(--color-primary);
+    animation: task-status-pulse 1.2s ease-in-out infinite;
+}
+
+.task-status--review {
+    background: var(--color-warning);
+}
+
+.task-status--planned {
+    background: var(--color-text-muted);
+}
+
+.task-status--done,
+.task-status--merged {
+    background: var(--color-success);
+}
+
+.task-status--failed,
+.task-status--rejected {
+    background: var(--color-danger);
+}
+
+@keyframes task-status-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(0.85); }
 }
 
 .page-tree-summary--section {

--- a/src/meshwiki/templates/base.html
+++ b/src/meshwiki/templates/base.html
@@ -32,6 +32,9 @@
                 <summary class="page-tree-summary">
                     <span class="page-tree-expand-icon">›</span>
                     <a href="/page/{{ node.name.replace(' ', '_') }}" class="page-tree-link{{ ' page-tree-link--done' if is_done else '' }}">{{ node.title }}</a>
+                    {% if node.status %}
+                    <span class="task-status task-status--{{ node.status }}" aria-label="{{ node.status }}"></span>
+                    {% endif %}
                 </summary>
                 {{ render_tree(node.children, level + 1) }}
             </details>
@@ -39,6 +42,9 @@
             {% set is_done = node.status in ('done', 'merged', 'failed', 'rejected') %}
             <div class="page-tree-leaf">
                 <a href="/page/{{ node.name.replace(' ', '_') }}" class="page-tree-link{{ ' page-tree-link--done' if is_done else '' }}">{{ node.title }}</a>
+                {% if node.status %}
+                <span class="task-status task-status--{{ node.status }}" aria-label="{{ node.status }}"></span>
+                {% endif %}
             </div>
             {% endif %}
         </li>

--- a/src/tests/test_page_tree.py
+++ b/src/tests/test_page_tree.py
@@ -336,3 +336,16 @@ def test_status_propagated_from_frontmatter():
 def test_status_defaults_to_empty_string():
     tree = build_page_tree_sync([_page("NoStatus")])
     assert tree[0]["status"] == ""
+
+
+def test_factory_task_node_has_status_in_tree():
+    """A factory task node includes status field in the tree JSON."""
+    pages = [
+        _page("Epic_001", children=["Task_001"]),
+        _page("Task_001", status="in_progress", assignee="factory"),
+    ]
+    tree = build_page_tree_sync(pages)
+    factory_section = next(n for n in tree if n.get("section"))
+    task_node = next(n for n in factory_section["children"] if n["name"] == "Task_001")
+    assert "status" in task_node
+    assert task_node["status"] == "in_progress"


### PR DESCRIPTION
## Summary
- Add colored status badges (8px dots) to Factory section nodes in the sidebar page tree
- `in_progress`: pulsing animation (CSS `@keyframes task-status-pulse`) in primary/accent color
- `review`: amber static dot (`--color-warning`)
- `planned`: gray static dot (`--color-text-muted`)
- `done`/`merged`: green static dot (`--color-success`)
- `failed`/`rejected`: red static dot (`--color-danger`)
- Badge renders inline with the link (no layout shift), works in both light and dark themes
- No JavaScript required — pure CSS animation for in_progress pulse

## Changes
- `src/meshwiki/templates/base.html`: render `<span class="task-status task-status--{{ node.status }}">` after the link anchor when `node.status` is non-empty (both `<details>` summary and leaf `<div>` cases)
- `src/meshwiki/static/css/style.css`: `.task-status` base class + per-status modifier classes + `@keyframes task-status-pulse`; added `--color-warning` and `--color-success` CSS custom properties
- `src/tests/test_page_tree.py`: new test `test_factory_task_node_has_status_in_tree`

## Testing
- 716 tests pass (32 skipped)
- Lint: black, isort, ruff all clean